### PR TITLE
feat: set up global state on jobs curator & country dropdown logic #JDY-31

### DIFF
--- a/src/apis/jobs/queries.ts
+++ b/src/apis/jobs/queries.ts
@@ -1,4 +1,4 @@
-import { Job } from "@/features/jobs-curator/types/jobs";
+import { Job, JobListQueryParams } from "@/features/jobs-curator/types/jobs";
 import client from "@/lib/axios/client";
 
 // API response structure
@@ -38,9 +38,15 @@ export async function getInternshipJobs() {
  * @desc Mock function to fetch jobs data from local JSON
  * @route GET /api/v2/jobs/
  */
-export async function getJobsMock(): Promise<JobsResponse> {
+export async function getJobsMock(
+  queryParams: JobListQueryParams
+): Promise<JobsResponse> {
   try {
-    const response = await fetch("/mocks/jobs.json");
+    const response = await fetch(
+      `/mocks/jobs.json?${new URLSearchParams(
+        queryParams as Record<string, string>
+      ).toString()}`
+    );
     if (!response.ok) {
       throw new Error("Failed to fetch mock jobs data");
     }

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -4,12 +4,23 @@ import React from "react";
 
 import { LoadingSpinner } from "@/components/ui/feedback";
 import useJobs from "@/features/jobs-curator/hooks/useJobs";
-import PositionDropdown from "@/features/jobs-curator/components/PositionDropdown";
+import JobCategoryDropdown from "@/features/jobs-curator/components/JobCategoryDropdown";
 import TagList from "@/features/jobs-curator/components/TagList";
 import JobPostingGrid from "@/features/jobs-curator/components/JobPostingGrid";
+import { JobsCuratorProvider } from "@/features/jobs-curator/contexts/JobsCuratorContext";
+import useJobsQueryParams from "@/features/jobs-curator/hooks/useJobsQueryParams";
 
 export default function JobsCuratorPage() {
-  const { jobs, status, error } = useJobs();
+  return (
+    <JobsCuratorProvider>
+      <JobsCuratorPageContent />
+    </JobsCuratorProvider>
+  );
+}
+
+function JobsCuratorPageContent() {
+  const queryParams = useJobsQueryParams();
+  const { jobs, status, error } = useJobs(queryParams);
 
   if (status === "loading") {
     return <LoadingSpinner />;
@@ -21,9 +32,9 @@ export default function JobsCuratorPage() {
 
   return (
     <section>
-      {/*  직군 선택 Dropdown (Heading) */}
+      {/* Job Category Dropdown - Heading */}
       <div className="mt-2 sm:mt-0">
-        <PositionDropdown />
+        <JobCategoryDropdown />
       </div>
 
       {/* Tag List */}

--- a/src/features/jobs-curator/components/JobCategoryDropdown.tsx
+++ b/src/features/jobs-curator/components/JobCategoryDropdown.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/shadcn/dropdown-menu";
 import { JobCategory } from "../types/jobs";
 import { sejongHospitalBold } from "@/utils/fonts/textFonts";
+import { useJobsCurator } from "../contexts/JobsCuratorContext";
 
 // TODO: need to sync this map with BE
 // also need to move this to constants file or somewhere else
@@ -22,14 +23,13 @@ const positionLabels: Record<JobCategory, string> = {
   sales: "영업",
 };
 
-export default function PositionDropdown() {
+export default function JobCategoryDropdown() {
   const [isOpen, setIsOpen] = useState(false);
   // NOTE: I think we need to store this in useContext globally
-  const [selectedPosition, setSelectedPosition] =
-    useState<JobCategory>("developer");
+  const { category, setCategory } = useJobsCurator();
 
   const handlePositionSelect = (position: JobCategory) => {
-    setSelectedPosition(position);
+    setCategory(position);
     setIsOpen(false);
   };
 
@@ -38,7 +38,7 @@ export default function PositionDropdown() {
       <DropdownMenuTrigger asChild>
         <button className="flex flex-row items-center gap-2">
           <h2 className={`${sejongHospitalBold.className} text-2xl`}>
-            {positionLabels[selectedPosition]}
+            {category ? positionLabels[category] : "전체"}
           </h2>
           <ChevronDownIcon className="w-6 h-6" />
         </button>
@@ -48,7 +48,7 @@ export default function PositionDropdown() {
           <DropdownMenuItem
             key={key}
             onClick={() => handlePositionSelect(key as JobCategory)}
-            selected={selectedPosition === key}
+            selected={category === key}
             className="text-1xl"
           >
             {label}

--- a/src/features/jobs-curator/components/JobPostingGrid/USAFallbackContent.tsx
+++ b/src/features/jobs-curator/components/JobPostingGrid/USAFallbackContent.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function USAFallbackContent() {
+  return <div>USAFallbackContent</div>;
+}

--- a/src/features/jobs-curator/components/JobPostingGrid/index.tsx
+++ b/src/features/jobs-curator/components/JobPostingGrid/index.tsx
@@ -1,13 +1,25 @@
 import React from "react";
-import { Job } from "../../types/jobs";
+
 import JobPostingCard from "./JobPostingCard";
+import USAFallbackContent from "./USAFallbackContent";
+
+import { useJobsCurator } from "../../contexts/JobsCuratorContext";
 import useFormattedJobs from "../../hooks/useFormattedJobs";
+import { Job } from "../../types/jobs";
 
 interface JobPostingGridProps {
   jobs: Job[];
 }
 
 export default function JobPostingGrid({ jobs }: JobPostingGridProps) {
+  const { selectedCountry } = useJobsCurator();
+  const isUSAFallback = selectedCountry === "미국";
+
+  // TODO: implement USA fallback view
+  if (isUSAFallback) {
+    return <USAFallbackContent />;
+  }
+
   if (jobs.length === 0) {
     return <div>No job postings found</div>;
   }

--- a/src/features/jobs-curator/components/TagList/CountryDropdown.tsx
+++ b/src/features/jobs-curator/components/TagList/CountryDropdown.tsx
@@ -10,14 +10,16 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/shadcn/dropdown-menu";
+import { useJobsCurator } from "../../contexts/JobsCuratorContext";
+import { SupportedCountry } from "../../types/jobs";
 
 const countries = ["한국", "미국"];
 
 export function CountryDropdown() {
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedCountry, setSelectedCountry] = useState("한국");
+  const { selectedCountry, setSelectedCountry } = useJobsCurator();
 
-  const handleCountrySelect = (country: string) => {
+  const handleCountrySelect = (country: SupportedCountry) => {
     setSelectedCountry(country);
     setIsOpen(false);
   };
@@ -36,7 +38,7 @@ export function CountryDropdown() {
         {countries.map((country) => (
           <DropdownMenuItem
             key={country}
-            onClick={() => handleCountrySelect(country)}
+            onClick={() => handleCountrySelect(country as SupportedCountry)}
             className={`${selectedCountry === country ? "bg-blue-50" : ""} ${
               sejongHospitalLight.className
             }`}

--- a/src/features/jobs-curator/contexts/JobsCuratorContext.tsx
+++ b/src/features/jobs-curator/contexts/JobsCuratorContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useState } from "react";
+import { SupportedCountry } from "../types/jobs";
+
+type JobsCuratorState = {
+  category: string | undefined;
+  setCategory: (c: string | undefined) => void;
+  selectedCountry: "한국" | "미국";
+  setSelectedCountry: (c: "한국" | "미국") => void;
+};
+
+const JobsCuratorContext = createContext<JobsCuratorState | undefined>(
+  undefined
+);
+
+export const JobsCuratorProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [selectedCountry, setSelectedCountry] =
+    useState<SupportedCountry>("한국");
+
+  const [category, setCategory] = useState<string | undefined>(undefined);
+
+  return (
+    <JobsCuratorContext.Provider
+      value={{ category, setCategory, selectedCountry, setSelectedCountry }}
+    >
+      {children}
+    </JobsCuratorContext.Provider>
+  );
+};
+
+export function useJobsCurator() {
+  const ctx = useContext(JobsCuratorContext);
+  if (!ctx)
+    throw new Error("useJobsCurator must be used within JobsCuratorProvider");
+  return ctx;
+}

--- a/src/features/jobs-curator/hooks/useJobs.ts
+++ b/src/features/jobs-curator/hooks/useJobs.ts
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { HookStatus } from "@/types/hook";
 import { getJobsMock } from "@/apis/jobs/queries";
-import { Job } from "../types/jobs";
+import { Job, JobListQueryParams } from "../types/jobs";
 
 // TODO: change it to use real API endpoint
-const useJobs = () => {
+const useJobs = (queryParams: JobListQueryParams) => {
   const [status, setStatus] = useState<HookStatus>("loading");
   const [jobs, setJobs] = useState<Job[]>([]);
   const [error, setError] = useState<string>();
@@ -12,7 +12,7 @@ const useJobs = () => {
   useEffect(() => {
     const fetchJobs = async () => {
       try {
-        const res = await getJobsMock();
+        const res = await getJobsMock(queryParams);
         // setJobs(res?.data); // NOTE: uncomment when using a real data
         setJobs(res?.jobs);
         setStatus("success");
@@ -27,7 +27,7 @@ const useJobs = () => {
     };
 
     fetchJobs();
-  }, []);
+  }, [queryParams]);
 
   return { jobs, status, error };
 };

--- a/src/features/jobs-curator/hooks/useJobsQueryParams.ts
+++ b/src/features/jobs-curator/hooks/useJobsQueryParams.ts
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+import { useJobsCurator } from "../contexts/JobsCuratorContext";
+import { JobListQueryParams } from "../types/jobs";
+
+export default function useJobsQueryParams() {
+  const { category } = useJobsCurator();
+
+  const queryParams: JobListQueryParams = useMemo(() => {
+    return {
+      category,
+    };
+  }, [category]);
+
+  return queryParams;
+}

--- a/src/features/jobs-curator/types/jobs.ts
+++ b/src/features/jobs-curator/types/jobs.ts
@@ -40,3 +40,17 @@ export type EmploymentType = "fulltime" | "internship";
 
 // Internship type
 export type InternshipType = "convertible" | "experiential" | "global";
+
+// Country
+export type SupportedCountry = "한국" | "미국";
+
+// Query parameters for the job list API
+type Tag = "fulltime" | "intern" | "convertible" | "experiential" | "global";
+export interface JobListQueryParams {
+  category?: string;
+  tags?: Tag[];
+  startDate?: string;
+  endDate?: string;
+  offset?: number;
+  limit?: number;
+}


### PR DESCRIPTION
## Description

- leveraged local states to global states on jobs curator application to manage query param better
- enabled country dropdown heading to update category query param to BE

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshot / Video

### Default: 전체 - category = undefined
<img width="1758" height="802" alt="스크린샷 2025-07-20 오후 8 57 30" src="https://github.com/user-attachments/assets/bcecb79b-e754-4693-86dc-ae31045eb46d" />


### 개발 - category = developer

<img width="1763" height="394" alt="스크린샷 2025-07-20 오후 8 58 11" src="https://github.com/user-attachments/assets/798a41b5-0119-4f49-9396-1aca8650329a" />
