### PR TITLE
[Phase 0.5 / 0.5.3] hybrid-auth: context + dev mock toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@stripe/stripe-js": "4.10.0",
         "@tailwindcss/postcss": "4.2.2",
         "@umichkisa-ds/form": "1.0.0",
-        "@umichkisa-ds/web": "1.0.1",
+        "@umichkisa-ds/web": "1.0.2",
         "@vercel/analytics": "1.3.1",
         "@vercel/speed-insights": "^1.3.1",
         "aws-sdk": "^2.1496.0",
@@ -12999,9 +12999,9 @@
       }
     },
     "node_modules/@umichkisa-ds/web": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@umichkisa-ds/web/-/web-1.0.1.tgz",
-      "integrity": "sha512-oHmhG+KtD/WOJB1Fl+MIW+9vBcnGCrHxALx6+ghjkKIEE6Xs8634s01aursympptaPnuJJ/jfp/ZBnLiYcdnRA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@umichkisa-ds/web/-/web-1.0.2.tgz",
+      "integrity": "sha512-ENvYUW7v+eMSSuVQSYZ76soHJFPDqhyKzCNihxKH8tllT7Id/2SvZb5VsEy1/bCFqP/PRCN0akcHhCpVSHiUiQ==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -94,5 +94,10 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.9.3",
     "vitest": "4.1.4"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@stripe/stripe-js": "4.10.0",
     "@tailwindcss/postcss": "4.2.2",
     "@umichkisa-ds/form": "1.0.0",
-    "@umichkisa-ds/web": "1.0.1",
+    "@umichkisa-ds/web": "1.0.2",
     "@vercel/analytics": "1.3.1",
     "@vercel/speed-insights": "^1.3.1",
     "aws-sdk": "^2.1496.0",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.13.2'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -5,6 +5,11 @@ import Footer from "@/components/layout/footer/Footer";
 import { sejongHospitalLight } from "@/utils/fonts/textFonts";
 import { getServerSession } from "next-auth";
 import authOptions from "@/lib/next-auth/authOptions";
+import {
+  AuthContextProvider,
+  MockAuthToggle,
+  type AppSession,
+} from "@/mocks/authContext";
 
 export default async function MainLayout({ children }: { children: ReactNode }) {
   // pass over this session to Header to remove unnecessary re-renders
@@ -14,26 +19,30 @@ export default async function MainLayout({ children }: { children: ReactNode }) 
   const mainContentsWidth = "max-w-screen-2xl px-4 md:px-24 lg:px-32";
 
   return (
-    <div className="h-full flex flex-col">
-      <header
-        className={`${sejongHospitalLight.className} top-0 z-40
-        bg-gradient-to-r from-michigan-blue/90 via-michigan-blue to-michigan-blue/85
-      text-white`}
-      >
-        <Header session={session} />
-      </header>
+    <AuthContextProvider initialSession={session as AppSession | null}>
+      <div className="h-full flex flex-col">
+        <header
+          className={`${sejongHospitalLight.className} top-0 z-40
+          bg-gradient-to-r from-michigan-blue/90 via-michigan-blue to-michigan-blue/85
+        text-white`}
+        >
+          <Header session={session} />
+        </header>
 
-      <main
-        className={`relative w-full h-full
-        mx-auto ${mainContentsWidth}
-        pt-3 md:pt-6 flex-1`}
-      >
-        {children}
-      </main>
+        <main
+          className={`relative w-full h-full
+          mx-auto ${mainContentsWidth}
+          pt-3 md:pt-6 flex-1`}
+        >
+          {children}
+        </main>
 
-      <footer className="mt-auto w-full">
-        <Footer />
-      </footer>
-    </div>
+        <footer className="mt-auto w-full">
+          <Footer />
+        </footer>
+
+        <MockAuthToggle />
+      </div>
+    </AuthContextProvider>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import "@umichkisa-ds/web/dist/styles.css";
+@import "@umichkisa-ds/web/theme.css";
 
 /* NextUI compat: keep NextUI content path scannable for class generation */
 @source "../../node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}";

--- a/src/mocks/authContext.tsx
+++ b/src/mocks/authContext.tsx
@@ -92,19 +92,19 @@ export function MockAuthToggle() {
     <div
       role="group"
       aria-label="Mock authentication toggle"
-      className="fixed bottom-4 right-4 z-50 flex items-center gap-3 rounded-full border border-border-strong bg-surface px-4 py-2 shadow-md"
+      className="fixed bottom-4 right-4 z-50 rounded-full border border-border-strong bg-surface px-4 py-2 shadow-md"
     >
       <Switch
         size="sm"
         checked={isAuthenticated}
         onChange={toggle}
+        text={
+          isAuthenticated
+            ? `Mock: ${MOCK_SESSION.user!.email}`
+            : "Mock: logged out"
+        }
         aria-label="Toggle mock authentication"
       />
-      <span className="type-body-sm text-foreground">
-        {isAuthenticated
-          ? `Mock: ${MOCK_SESSION.user!.email}`
-          : "Mock: logged out"}
-      </span>
     </div>
   );
 }

--- a/src/mocks/authContext.tsx
+++ b/src/mocks/authContext.tsx
@@ -92,18 +92,23 @@ export function MockAuthToggle() {
     <div
       role="group"
       aria-label="Mock authentication toggle"
-      className="fixed bottom-4 right-4 z-50 min-w-72 rounded-full border border-border-strong bg-surface px-4 py-2 shadow-md"
+      className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border border-border-strong bg-surface px-4 py-2 shadow-md"
     >
       <Switch
         checked={isAuthenticated}
         onChange={toggle}
-        text={
-          isAuthenticated
-            ? `Mock: ${MOCK_SESSION.user!.email}`
-            : "Mock: logged out"
-        }
         aria-label="Toggle mock authentication"
       />
+      <span className="relative type-body-sm text-foreground">
+        <span aria-hidden="true" className="invisible">
+          Mock: {MOCK_SESSION.user!.email}
+        </span>
+        <span className="absolute inset-0">
+          {isAuthenticated
+            ? `Mock: ${MOCK_SESSION.user!.email}`
+            : "Mock: logged out"}
+        </span>
+      </span>
     </div>
   );
 }

--- a/src/mocks/authContext.tsx
+++ b/src/mocks/authContext.tsx
@@ -92,10 +92,9 @@ export function MockAuthToggle() {
     <div
       role="group"
       aria-label="Mock authentication toggle"
-      className="fixed bottom-4 right-4 z-50 rounded-full border border-border-strong bg-surface px-4 py-2 shadow-md"
+      className="fixed bottom-4 right-4 z-50 min-w-72 rounded-full border border-border-strong bg-surface px-4 py-2 shadow-md"
     >
       <Switch
-        size="sm"
         checked={isAuthenticated}
         onChange={toggle}
         text={

--- a/src/mocks/authContext.tsx
+++ b/src/mocks/authContext.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { Session } from "next-auth";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { Switch } from "@umichkisa-ds/web";
+
+type AppSession = Session & { token: string };
+
+const MOCK_SESSION: AppSession = {
+  user: {
+    name: "KISA Tester",
+    email: "tester@umich.edu",
+    image: "/default_profile.png",
+  },
+  token: "mock-access-token",
+  expires: new Date(Date.now() + 86_400_000).toISOString(),
+};
+
+const IS_MOCK_MODE = process.env.NEXT_PUBLIC_MOCK_API === "1";
+const STORAGE_KEY = "kisa-mock-auth-authenticated";
+
+type AuthContextValue = {
+  session: AppSession | null;
+  isAuthenticated: boolean;
+  toggle: () => void;
+  isMockMode: boolean;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthContextProvider({
+  initialSession,
+  children,
+}: {
+  initialSession: AppSession | null;
+  children: ReactNode;
+}) {
+  const [mockAuthed, setMockAuthed] = useState(false);
+
+  useEffect(() => {
+    if (IS_MOCK_MODE) {
+      const stored = sessionStorage.getItem(STORAGE_KEY);
+      if (stored === "1") {
+        setMockAuthed(true);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (IS_MOCK_MODE) {
+      sessionStorage.setItem(STORAGE_KEY, mockAuthed ? "1" : "0");
+    }
+  }, [mockAuthed]);
+
+  const value: AuthContextValue = IS_MOCK_MODE
+    ? {
+        session: mockAuthed ? MOCK_SESSION : null,
+        isAuthenticated: mockAuthed,
+        toggle: () => setMockAuthed((p) => !p),
+        isMockMode: true,
+      }
+    : {
+        session: initialSession,
+        isAuthenticated: initialSession !== null,
+        toggle: () => {},
+        isMockMode: false,
+      };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useMockAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useMockAuth must be used within <AuthContextProvider>");
+  }
+  return ctx;
+}
+
+export function MockAuthToggle() {
+  const { isMockMode, isAuthenticated, toggle } = useMockAuth();
+
+  if (!isMockMode) return null;
+
+  return (
+    <div
+      role="group"
+      aria-label="Mock authentication toggle"
+      className="fixed bottom-4 right-4 z-50 flex items-center gap-3 rounded-full border border-border-strong bg-surface px-4 py-2 shadow-md"
+    >
+      <Switch
+        size="sm"
+        checked={isAuthenticated}
+        onChange={toggle}
+        aria-label="Toggle mock authentication"
+      />
+      <span className="type-body-sm text-foreground">
+        {isAuthenticated
+          ? `Mock: ${MOCK_SESSION.user!.email}`
+          : "Mock: logged out"}
+      </span>
+    </div>
+  );
+}
+
+export type { AppSession };


### PR DESCRIPTION
Closes #48

## Summary

Adds hybrid auth plumbing: real next-auth flow stays untouched in prod; a dev-only floating toggle widget lets reviewers flip logged-in/out states in Vercel dev preview (`NEXT_PUBLIC_MOCK_API=1`) without real Google OAuth.

## Scope tag
`[REDESIGN]` `[NO-TDD]`

## Changes

**New: `src/mocks/authContext.tsx` (~110 LoC)**
- `AuthContextProvider({ initialSession, children })` — always mounts; seeded with the server-fetched Session. In mock mode, state is toggle-controlled + persisted via `sessionStorage` (key `kisa-mock-auth-authenticated`); in prod, returns `{ session: initialSession, ... }` with a no-op `toggle`.
- `useMockAuth()` — throws if used outside the provider. Returns `{ session, isAuthenticated, toggle, isMockMode }`. Safe to call in both prod and mock — no env branching at call-sites. 0.5.4c will wire Header to this hook.
- `MockAuthToggle` — self-hides when `!isMockMode`. Fixed `bottom-4 right-4 z-50` pill using DS `Switch size="sm"` + status label (`Mock: tester@umich.edu` / `Mock: logged out`).
- Local `type AppSession = Session & { token: string }` alias — next-auth's `Session` isn't augmented with `token` in this repo (see `authOptions.ts:30`). Exported for consumer typing. Module-augmentation is a separate hygiene follow-up (would sweep existing `session.token` usages).

**Modify: `src/app/(main)/layout.tsx`**
- Wraps the existing flex shell in `<AuthContextProvider initialSession={session as AppSession | null}>`.
- Renders `<MockAuthToggle />` inside the provider.
- `<Header session={session} />` prop consumption is unchanged — hook wiring is deferred to 0.5.4c per plan.

## Files NOT touched (scope deltas from original issue)

After the 0.5.1 merge, `template.tsx` no longer fetches session and `MSWProvider` doesn't need to know about auth context. Full reasoning + bailout reassessment in the issue #48 scope-revision comment.

- ~~`src/mocks/MSWProvider.tsx`~~ — MSW init order is enforced by tree (`AuthContextProvider` is a descendant of `MSWProvider`; MSW finishes loading before the subtree mounts).
- ~~`src/app/template.tsx`~~ — pass-through post-0.5.1; no session fetch to branch on.

## Mock session payload

`next-auth` Session-compatible:
```ts
{
  user: {
    name: "KISA Tester",
    email: "tester@umich.edu",
    image: "/default_profile.png",  // existing local asset
  },
  token: "mock-access-token",
  expires: <Date.now()+24h, ISO>,
}
```

## Verification

- [x] `npm run build` — passes (full webpack + lint + type-check + static gen)
- [x] `npx tsc --noEmit` — no new errors in the lane's files (pre-existing errors in `shadcn/` and `deprecated-components/` are unrelated)
- [x] DS client constraint review — PASS (no violations)
- [x] All colors via DS semantic tokens (`border-border-strong`, `bg-surface`, `text-foreground`)
- [x] Typography via DS `type-body-sm` paired with color token
- [x] Uses DS `Switch` (not `Form.Switch`, since this isn't a form context)
- [x] `"use client"` directive on authContext.tsx
- [x] `sessionStorage` writes guarded by `IS_MOCK_MODE` to avoid prod writes
- [x] Hydration-safe: initial state is `false`, mount-effect restores from storage

## Manual test protocol (Vercel dev preview or local `npm run dev` with `NEXT_PUBLIC_MOCK_API=1`)

1. Widget visible at bottom-right on all `(main)` routes (not on pocha, which uses its own auth shell)
2. Click Switch → pill label flips between `Mock: tester@umich.edu` and `Mock: logged out`
3. Navigate `/` → `/boards` → `/info` — toggle state persists (layout-scoped context, doesn't remount)
4. Reload — toggle state restored from sessionStorage
5. Header UI **unchanged regardless of toggle** — this is expected; Header still reads the `session` prop. Toggle affects only the context value, which no consumer reads yet (0.5.4c wires it in).

## Prod-safety notes

- `NEXT_PUBLIC_MOCK_API` is inlined at build time. `IS_MOCK_MODE = process.env.NEXT_PUBLIC_MOCK_API === "1"` evaluates to `false` in prod builds → `MockAuthToggle` returns `null`, sessionStorage never touched, toggle is a no-op.
- Vercel env scope confirmed: `NEXT_PUBLIC_MOCK_API=1` set for **Preview** (dev branch), unset for **Production** (main branch).

## Follow-ups (tracked separately, not in this PR)

1. Add `declare module "next-auth"` augmentation in `src/types/next-auth.d.ts` for `Session.token: string` — would replace the local `AppSession` alias and retroactively type all existing `session.token` accesses.
2. Lane 0.5.4c wires Header to `useMockAuth()` — at that point the toggle will actually flip the Header's authed/unauthed UI.
