### PR TITLE
[Phase 0.5] header: restore WebTitle wordmark (fix lane 0.5.4a dead-code miss)

### DIFF
--- a/src/components/layout/header/HeaderTitle.tsx
+++ b/src/components/layout/header/HeaderTitle.tsx
@@ -4,16 +4,22 @@ import React from "react";
 
 export default function HeaderTitle() {
   return (
-    <div className="flex items-center gap-5">
-      <Link href="/" className="flex flex-col items-start gap-0">
-        <Image
-          src="/kisa_logo.png"
-          alt="KISA Logo"
-          width={48}
-          height={48}
-          className="object-contain"
-        />
-      </Link>
-    </div>
+    <Link
+      href="/"
+      aria-label="KISA home"
+      className="flex items-center gap-5"
+    >
+      <Image
+        src="/kisa_logo.png"
+        alt="KISA Logo"
+        width={48}
+        height={48}
+        className="object-contain"
+      />
+      <span className="flex flex-col items-start gap-0">
+        <span className="text-white type-label">University of Michigan</span>
+        <span className="text-white type-h2">한인 학생회</span>
+      </span>
+    </Link>
   );
 }


### PR DESCRIPTION
## Summary
Restore the "University of Michigan / 한인 학생회" wordmark that was silently dropped from the header during lane 0.5.4a's dead-code cleanup.

Surfaced during PR #61 review: maintainer noticed the wordmark missing from the desktop deployment preview.

## Root cause

Phase 0.5 audit §0.5.4a classified `WebTitle.jsx` as `[DEAD] (commented out in Header.jsx, no other callers)` — and locked decision #11 said "WebTitle content is dead, don't include" when merging `HeaderTitleBlock` + `WebLogo` + `WebTitle` into a single `HeaderTitle.tsx`.

That analysis was grep'd against `Header.jsx` only. It missed that `WebTitle` was imported and rendered by `HeaderTitleBlock.jsx` — live, not commented out:

```jsx
// HeaderTitleBlock.jsx (pre-0.5.4a, deleted by PR #58)
import WebLogo from "./WebLogo";
import WebTitle from "./WebTitle";

export default function HeaderTitleBlock() {
  return (
    <div className="flex items-center gap-5">
      <WebLogo />
      <WebTitle />
    </div>
  );
}
```

Lane 0.5.4a (PR #58) merged `HeaderTitleBlock` + `WebLogo` but skipped `WebTitle`, producing a logo-only `HeaderTitle.tsx`.

## Changes

`src/components/layout/header/HeaderTitle.tsx` — add back the wordmark, retokenized to DS primitives per Phase 0.5 norms:

- Wrap logo + wordmark in a single `<Link href="/" aria-label="KISA home">` — replaces the pre-migration pattern of two sibling links both pointing to `/`. Cleaner semantics: one home link with logo + text children.
- `University of Michigan`: `type-label text-white` (flat 0.875rem / weight 500, Pretendard). Original was `text-xs md:text-sm font-bold ${sejongHospitalBold.className}` — locked decision #12 drops the sejong overrides; `type-label` matches the brand-wordmark-small role.
- `한인 학생회`: `type-h2 text-white` (responsive 1.25→1.375→1.5rem across md: and lg:, Pretendard). Original was `text-xl lg:text-2xl font-bold ${sejongHospitalBold.className}` — `type-h2`'s responsive scaling matches the original intent almost exactly.
- `<span>` not `<h1>`. The original double-`<h1>` pattern was invalid (two page-level headings). Inline text spans are correct for a wordmark.

## Verification

- [x] `npx tsc --noEmit` passes.
- [x] Grep: no `sejongHospitalBold` / `heebo` / `text-xs` / `text-xl` / `font-bold` classes in `HeaderTitle.tsx`.
- [x] Paired color tokens: both text spans get `text-white` alongside their `type-*` class.
- [ ] Visual verification on dev preview (no chrome tooling in the autonomous VM — couldn't run a live browser check).

## Scope

Not a new lane. Filed as a bug-fix follow-up to lane 0.5.4a. No new GitHub issue — it corrects a dead-code misclassification in the phase audit rather than implementing new planned work.

## Notes

- If the chosen type-* mapping doesn't feel right once you see it on the preview, easy knobs: `type-label` → `type-caption` (0.75rem, matches mobile original more faithfully) for the English line, or swap `type-h2` → `type-h3` (smaller) or `type-h1` (larger) for the Korean line.
- The Phase 0.5 audit file in `umichkisa-ds/docs/plans/client-migration/phase-0.5-layout/audit.md` still carries the "WebTitle dead" claim — worth a docs fix in a separate DS PR if we want the audit to match the as-built header.