### PR TITLE
[Phase 0.5 / 0.5.6] Shell → DS Container (site-wide)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@stripe/stripe-js": "4.10.0",
         "@tailwindcss/postcss": "4.2.2",
         "@umichkisa-ds/form": "1.0.0",
-        "@umichkisa-ds/web": "1.0.2",
+        "@umichkisa-ds/web": "1.0.3",
         "@vercel/analytics": "1.3.1",
         "@vercel/speed-insights": "^1.3.1",
         "aws-sdk": "^2.1496.0",
@@ -12999,9 +12999,9 @@
       }
     },
     "node_modules/@umichkisa-ds/web": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@umichkisa-ds/web/-/web-1.0.2.tgz",
-      "integrity": "sha512-ENvYUW7v+eMSSuVQSYZ76soHJFPDqhyKzCNihxKH8tllT7Id/2SvZb5VsEy1/bCFqP/PRCN0akcHhCpVSHiUiQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@umichkisa-ds/web/-/web-1.0.3.tgz",
+      "integrity": "sha512-/jco5Of/BcECwEgwyn2TnkarzYNxlxkjGpc84zWx5fcsjvBaAlDpT8xWqGnw5fmSn9AHzUE4IVUIsH/rptAMVg==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@stripe/stripe-js": "4.10.0",
     "@tailwindcss/postcss": "4.2.2",
     "@umichkisa-ds/form": "1.0.0",
-    "@umichkisa-ds/web": "1.0.2",
+    "@umichkisa-ds/web": "1.0.3",
     "@vercel/analytics": "1.3.1",
     "@vercel/speed-insights": "^1.3.1",
     "aws-sdk": "^2.1496.0",

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 import Header from "@/components/layout/header/Header";
 import Footer from "@/components/layout/footer/Footer";
 import { getServerSession } from "next-auth";
-import { cn } from "@umichkisa-ds/web";
+import { Container } from "@umichkisa-ds/web";
 import authOptions from "@/lib/next-auth/authOptions";
 import {
   AuthContextProvider,
@@ -13,8 +13,6 @@ import {
 
 export default async function MainLayout({ children }: { children: ReactNode }) {
   const session = await getServerSession(authOptions);
-
-  const mainContentsWidth = "max-w-screen-2xl px-4 md:px-24 lg:px-32";
 
   return (
     <AuthContextProvider initialSession={session as AppSession | null}>
@@ -27,15 +25,9 @@ export default async function MainLayout({ children }: { children: ReactNode }) 
           <Header />
         </header>
 
-        <main
-          className={cn(
-            "relative w-full h-full mx-auto",
-            mainContentsWidth,
-            "pt-3 md:pt-6 flex-1"
-          )}
-        >
+        <Container as="main" className="relative h-full pt-3 md:pt-6 flex-1">
           {children}
-        </main>
+        </Container>
 
         <footer className="mt-auto w-full">
           <Footer />

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -25,7 +25,7 @@ export default async function MainLayout({ children }: { children: ReactNode }) 
           <Header />
         </header>
 
-        <Container as="main" size="lg" className="relative h-full pt-3 md:pt-6 flex-1">
+        <Container as="main" size="xl" className="relative h-full pt-3 md:pt-6 flex-1">
           {children}
         </Container>
 

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -25,7 +25,7 @@ export default async function MainLayout({ children }: { children: ReactNode }) 
           <Header />
         </header>
 
-        <Container as="main" className="relative h-full pt-3 md:pt-6 flex-1">
+        <Container as="main" size="lg" className="relative h-full pt-3 md:pt-6 flex-1">
           {children}
         </Container>
 

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -40,7 +40,7 @@ export default function Header() {
   const userName = session?.user?.name ?? "User";
 
   return (
-    <Container size="lg" className="relative inset-x-0 z-50 flex justify-between items-center py-3 md:py-4">
+    <Container size="xl" className="relative inset-x-0 z-50 flex justify-between items-center py-3 md:py-4">
       {/* LEFT SIDE */}
       <div
         className="flex flex-col md:flex-row

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -40,7 +40,7 @@ export default function Header() {
   const userName = session?.user?.name ?? "User";
 
   return (
-    <Container className="relative inset-x-0 z-50 flex justify-between items-center py-3 md:py-4">
+    <Container size="lg" className="relative inset-x-0 z-50 flex justify-between items-center py-3 md:py-4">
       {/* LEFT SIDE */}
       <div
         className="flex flex-col md:flex-row

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Divider, Icon, cn } from "@umichkisa-ds/web";
+import { Container, Divider, Icon, cn } from "@umichkisa-ds/web";
 
 import LoginButton from "./LoginButton";
 import UserInfo from "./UserInfo";
@@ -24,8 +24,6 @@ import { useMockAuth } from "@/mocks/authContext";
 const INSTAGRAM_URL = "https://www.instagram.com/kisa_michigan/";
 
 export default function Header() {
-  const headerContentWidth = "max-w-screen-2xl px-4 md:px-24 lg:px-32";
-
   const { session, isAuthenticated } = useMockAuth();
 
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState<boolean>(false);
@@ -42,15 +40,7 @@ export default function Header() {
   const userName = session?.user?.name ?? "User";
 
   return (
-    <div
-      className={cn(
-        "mx-auto",
-        headerContentWidth,
-        "relative inset-x-0 w-full z-50",
-        "flex justify-between items-center",
-        "py-3 md:py-4"
-      )}
-    >
+    <Container className="relative inset-x-0 z-50 flex justify-between items-center py-3 md:py-4">
       {/* LEFT SIDE */}
       <div
         className="flex flex-col md:flex-row
@@ -158,6 +148,6 @@ export default function Header() {
         )}
         <LoginButton isAuthenticated={isAuthenticated} size="sm" />
       </div>
-    </div>
+    </Container>
   );
 }


### PR DESCRIPTION
Closes #67

## Summary

Phase 0.5 lane 0.5.6: swap manually composed page shells for DS `Container`. Clears violation V3 surfaced by `ds-client-review` during lane 0.5.4c (PR #66).

## Changes

**`src/components/layout/header/Header.tsx`**
- Add `Container` to the existing `@umichkisa-ds/web` named import.
- Delete `headerContentWidth = "max-w-screen-2xl px-4 md:px-24 lg:px-32"` const.
- Outer `<div>` → `<Container className="relative inset-x-0 z-50 flex justify-between items-center py-3 md:py-4">`. Container supplies `mx-auto w-full px-4 md:px-6 lg:px-8 max-w-screen-2xl`; passthrough is layout/positioning only.

**`src/app/(main)/layout.tsx`**
- Replace `{ cn }` import with `{ Container }` (cn was only used by the `<main>` wrapper).
- Delete `mainContentsWidth = "max-w-screen-2xl px-4 md:px-24 lg:px-32"` const.
- `<main>` → `<Container as="main" className="relative h-full pt-3 md:pt-6 flex-1">`.

## Scope decision

Per the 2026-04-19 grill-session on lane 0.5.6 (see `docs/plans/client-migration/phase-0.5-layout/plan.md`), ship **DS Container default padding** (`px-4 md:px-6 lg:px-8`) and deliberately drop the brand-wide padding (`md:px-24 lg:px-32`). This matches how the DS docs app already consumes `Container`.

## Deviations from original

- **Horizontal gutters shrink at md+ only.** `md`: `px-24 → px-6` (~72px per side smaller). `lg`: `px-32 → px-8` (~96px per side smaller). Mobile is unchanged (`px-4` on both sides).
- This is the point of the change — revisit if any route looks too stretched; do NOT re-introduce brand-wide padding locally. Rollback path: add a `padding` variant to DS `Container` in a follow-up, then re-run this lane consuming `<Container padding="wide">`.

## Out of scope

- `src/app/(pocha)/pocha/history/page.tsx` — uses `px-2 max-w-screen-2xl mx-auto` inside the `(pocha)` route group (no Header/Footer). Deferred to Phase 2 (pocha).
- `src/app/(main)/signup/page.js` — uses `max-w-4xl h-full mx-auto mb-20`. Page-internal content narrowing, not a shell; no Container size equivalent for `max-w-4xl`. Not tracked in this lane.

## Verification

- [x] `npx tsc --noEmit` passes.
- [x] `ds-client-review` PASS (V3 cleared, no new violations).
- [ ] **Visual smoke test (needs reviewer eye on Vercel preview):** side-by-side vs `dev` at lg / md / mobile:
  - [ ] `/` (home)
  - [ ] `/jobs`
  - [ ] `/boards`
  - [ ] `/posts`
  - [ ] `/about`
  - [ ] `/signin`
  - [ ] `/signup`
- [ ] No regressions in header layout (logo placement, nav dropdown anchoring, mobile menu positioning).

If any md+ route looks too stretched → STOP; open a DS follow-up to add a `padding` variant to `Container`; do not re-introduce brand-wide padding locally.
