### PR TITLE
[Phase 2 / 2.5] PreviousPochaList: useEffect → SWR

### DIFF
--- a/src/features/pocha/components/manage/PreviousPochaList.tsx
+++ b/src/features/pocha/components/manage/PreviousPochaList.tsx
@@ -1,10 +1,10 @@
 // PreviousPochaList.tsx
 import { HorizontalDivider } from '@/components/ui/divider';
 import { sejongHospitalBold } from '@/utils/fonts/textFonts';
-import { useEffect, useState } from 'react';
-import { getPreviousPochaList } from '@/apis/pocha/queries';
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { fetcher } from '@/lib/swr/fetchers';
 import React from 'react';
-import { HookStatus } from '@/types/hook';
 import { PochaInfoWithoutStatus } from '@/types/pocha';
 import PreviousPochaSummary from './PreviosPochaSummary';
 
@@ -17,40 +17,45 @@ function PreviousPochaList({
   onSelectPocha,
   selectedPochaId,
 }: PreviousPochaListProps) {
-  const [status, setStatus] = useState<HookStatus>('loading');
-  const [previousPochaList, setPreviousPochaList] =
-    useState<PochaInfoWithoutStatus[]>();
-  const [error, setError] = useState<string>();
+  const dateIso = useMemo(
+    () => new Date().toISOString().split('.')[0],
+    []
+  );
 
-  useEffect(() => {
-    const fetchPreviousPochaList = async () => {
-      try {
-        const res = await getPreviousPochaList(new Date());
-        setPreviousPochaList(res);
-        setStatus('success');
-      } catch (error) {
-        setStatus('error');
-        if (error instanceof Error) {
-          setError(error.message);
-        } else {
-          setError('An unexpected error occurred.');
-        }
-      }
-    };
-    fetchPreviousPochaList();
-  }, []);
+  const {
+    data: rawList,
+    error,
+    isLoading,
+  } = useSWR<PochaInfoWithoutStatus[]>(
+    `/pocha/previous/?date=${dateIso}`,
+    fetcher
+  );
 
-  if (status === 'loading') {
+  const previousPochaList = useMemo(
+    () =>
+      rawList?.map((pocha) => ({
+        ...pocha,
+        startDate: new Date(pocha.startDate),
+        endDate: new Date(pocha.endDate),
+      })),
+    [rawList]
+  );
+
+  if (isLoading) {
     return <></>;
   }
 
-  if (status === 'error') {
+  if (error) {
     return (
       <div className='flex flex-col w-full gap-6 items-center justify-center p-8'>
         <p className='text-red-500'>
           이전 포차 정보를 불러오는데 실패했습니다.
         </p>
-        <p className='text-sm text-gray-500'>{error}</p>
+        <p className='text-sm text-gray-500'>
+          {error instanceof Error
+            ? error.message
+            : 'An unexpected error occurred.'}
+        </p>
       </div>
     );
   }


### PR DESCRIPTION
Closes #91

## Summary
Behavior-preserving data-layer migration: replace the `useEffect` + `useState(status/list/error)` block in `PreviousPochaList` with `useSWR` using the token-less `fetcher` from `@/lib/swr/fetchers`. Visual output preserved verbatim — redesign happens in lane 2.7.

## Changes
- `src/features/pocha/components/manage/PreviousPochaList.tsx`: drop `useEffect`/`useState` fetch state + `getPreviousPochaList` import; add `useSWR(`/pocha/previous/?date=…`, fetcher)`; move `startDate`/`endDate` string → `Date` transformation into a `useMemo` over the fetched payload; stabilize the date key with `useMemo(() => new Date().toISOString().split('.')[0], [])` so SWR treats the fetch as one-shot-on-mount (matches the prior `useEffect(..., [])` semantics).

## Verification
- [x] `npx tsc --noEmit` passes (only pre-existing `moduleResolution=node10` deprecation warning remains)
- [x] `npm run lint` passes (no warnings or errors)
- [x] `npm run build` passes (with dummy Stripe env vars required by unrelated `/api/create-tip-payment-intent` route; no build errors in the touched file's chunk)
- [x] `ds-client-review`: no-op — no new DS imports, JSX unchanged (lane is data-layer only per issue scope)
- [ ] Manual smoke: list populates from MSW fixtures (requires `NEXT_PUBLIC_MOCK_API=1` Vercel preview — not executable in the autonomous env)

## Scope tag
`[MECHANICAL]` `[NO-TDD]` — matches issue spec

## Notes
- Fetcher choice: plain `fetcher` (token-less). The `/pocha/previous/` endpoint does not require `Authorization` per `src/apis/pocha/queries.ts` and the MSW handler at `src/mocks/handlers/pocha.ts` — so the bailout trigger on fetcher ambiguity did not fire.
- `getPreviousPochaList` from `src/apis/pocha/queries.ts` is now unused by this file but other callers — none found via grep, but left in place (pruning is out of scope for this lane).
- The empty/error/success JSX branches were preserved verbatim, including the raw `text-red-500` / `text-gray-500` classes. Lane 2.7 retokenizes these.

🤖 Autonomous routine — see `AUTONOMOUS_PROTOCOL.md` §5

---
_Generated by [Claude Code](https://claude.ai/code/session_0135oraY1q1wyztf9WYdcsvm)_