### PR TITLE
[Phase 2 / 2.8] PochaManagePageHeader: sejongHospitalBold → type-h1

### DIFF
--- a/src/features/pocha/components/manage/PochaManagePageHeader.tsx
+++ b/src/features/pocha/components/manage/PochaManagePageHeader.tsx
@@ -5,7 +5,6 @@ import { useSession } from "next-auth/react";
 import LoginButton from "@/components/layout/header/LoginButton";
 import UserInfo from "@/components/layout/header/UserInfo";
 import { UserSession } from "@/lib/next-auth/types";
-import { sejongHospitalBold } from "@/utils/fonts/textFonts";
 
 export default function PochaManagePageHeader() {
   const { data: session } = useSession() as {
@@ -15,9 +14,7 @@ export default function PochaManagePageHeader() {
 
   return (
     <div className="relative flex min-h-[4.5rem] items-center justify-between gap-4 overflow-hidden py-2">
-      <h1
-        className={`relative z-10 ${sejongHospitalBold.className} text-3xl`}
-      >
+      <h1 className="type-h1 relative z-10 text-foreground">
         포차 관리
       </h1>
       <div className="relative z-10 flex items-center gap-4">


### PR DESCRIPTION
Closes #94

## Summary
Retokenize the `<h1>포차 관리</h1>` in `PochaManagePageHeader` to use the DS `type-h1` token (which carries the Sejong display face), replacing the explicit `sejongHospitalBold` + `text-3xl` pair. Container sizing and sibling `UserInfo` / `LoginButton` composition untouched.

## Changes
- `src/features/pocha/components/manage/PochaManagePageHeader.tsx`: drop `sejongHospitalBold` import + class; add `type-h1 text-foreground` on the `<h1>`; keep existing `relative z-10` and `min-h-[4.5rem]` container sizing per issue.

## Verification
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes (no warnings or errors)
- [x] `ds-client-review`: no `sejongHospital*` in file; `type-h1` matches Phase 1 precedent (`JobApplicationInfoContents`)
- [ ] Manual smoke at 375px + 1280px: requires Vercel `dev` preview

## Scope tag
`[POLISH]` `[NO-TDD]` — matches issue spec

## Notes
- Bailout trigger ("no DS equivalent for `min-h-[4.5rem]`") did NOT fire; issue says "keep literal, note in PR" — container min-height kept as-is.
- `UserInfo` / `LoginButton` untouched per non-goals.

🤖 Autonomous routine — see `AUTONOMOUS_PROTOCOL.md` §5

---
_Generated by [Claude Code](https://claude.ai/code/session_0135oraY1q1wyztf9WYdcsvm)_