### PR TITLE
[Phase 2 / 2.9] PochaSummary: DS Card + Badge retokenize

### DIFF
--- a/src/features/pocha/components/manage/PochaSummary.tsx
+++ b/src/features/pocha/components/manage/PochaSummary.tsx
@@ -1,11 +1,15 @@
 import React from "react";
-import { MenuItemRaw, PochaInfo } from "@/types/pocha";
 import {
-  sejongHospitalBold,
-  sejongHospitalLight,
-} from "@/utils/fonts/textFonts";
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@umichkisa-ds/web";
+
+import { MenuItemRaw, PochaInfo } from "@/types/pocha";
 import { formatDateTimeString } from "@/utils/formats/date";
-import CustomButton from "@/components/ui/button/CustomButton";
 
 interface PochaSummaryProps {
   pochaInfo: PochaInfo;
@@ -13,62 +17,64 @@ interface PochaSummaryProps {
   setIsEditPochaFormOpen: (isOpen: boolean) => void;
   menuList: MenuItemRaw[];
 }
+
 export default function PochaSummary({
   pochaInfo,
   isEditPochaFormOpen,
   setIsEditPochaFormOpen,
   menuList,
 }: PochaSummaryProps) {
-
+  const statusLabel = pochaInfo.ongoing ? "진행 중" : "진행 예정";
+  const statusVariant = pochaInfo.ongoing ? "success" : "default";
 
   return (
-    <div
-      className={`flex flex-col ${sejongHospitalBold.className} gap-2
-      bg-gray-100 p-4 rounded-lg hover:bg-gray-200 transition-colors
-    `}
-    >
-      <div className='flex justify-between items-center'>
-        <h2 className='text-xl'>
-          {pochaInfo.title}
-          {pochaInfo.ongoing ? ' (진행 중)' : ' (진행 예정)'}
-        </h2>
-        <CustomButton
-          text={isEditPochaFormOpen ? '수정 취소' : '수정하기'}
-          onClick={() => {
-            setIsEditPochaFormOpen(!isEditPochaFormOpen);
-          }}
-        />
-      </div>
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <CardTitle as="h3" className="type-h3 !font-semibold">
+              {pochaInfo.title}
+            </CardTitle>
+            <Badge variant={statusVariant}>{statusLabel}</Badge>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setIsEditPochaFormOpen(!isEditPochaFormOpen)}
+          >
+            {isEditPochaFormOpen ? "수정 취소" : "수정하기"}
+          </Button>
+        </div>
+      </CardHeader>
 
-      <div className='flex flex-col gap-2 text-lg'>
-        <span>
-          설명:{' '}
-          <span className={`${sejongHospitalLight.className}`}>
-            {pochaInfo.description}
-          </span>
-        </span>
-        <span>
-          시작 날짜:{' '}
-          <span className={`${sejongHospitalLight.className}`}>
-            {formatDateTimeString(pochaInfo.startDate)}
-          </span>
-        </span>
-        <span>
-          종료 날짜:{' '}
-          <span className={`${sejongHospitalLight.className}`}>
-            {formatDateTimeString(pochaInfo.endDate)}
-          </span>
-        </span>
-      </div>
-
-      <div className='flex flex-col gap-2 text-lg'>
-        <span>
-          메뉴:{' '}
-          <span className={`${sejongHospitalLight.className}`}>
-            {menuList.map((menu) => menu.nameKor).join(', ')}
-          </span>
-        </span>
-      </div>
-    </div>
+      <CardContent>
+        <div className="flex flex-col gap-2">
+          <p className="type-body">
+            <span>설명: </span>
+            <span className="text-muted-foreground">
+              {pochaInfo.description}
+            </span>
+          </p>
+          <p className="type-body">
+            <span>시작 날짜: </span>
+            <span className="text-muted-foreground">
+              {formatDateTimeString(pochaInfo.startDate)}
+            </span>
+          </p>
+          <p className="type-body">
+            <span>종료 날짜: </span>
+            <span className="text-muted-foreground">
+              {formatDateTimeString(pochaInfo.endDate)}
+            </span>
+          </p>
+          <p className="type-body">
+            <span>메뉴: </span>
+            <span className="text-muted-foreground">
+              {menuList.map((menu) => menu.nameKor).join(", ")}
+            </span>
+          </p>
+        </div>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
Closes #95

## Summary
Retokenize `PochaSummary` onto DS `Card` + `CardHeader` + `CardTitle` + `CardContent` primitives. Status `(진행 중)` / `(진행 예정)` becomes a `Badge` (`success` when ongoing, `default` otherwise). The `CustomButton` edit toggle becomes a DS `Button` (`variant="secondary"`, `size="sm"`). All `sejongHospital*` body usage removed; labels use `type-body`, values use `text-muted-foreground`.

## Changes
- `src/features/pocha/components/manage/PochaSummary.tsx`: swap outer `<div>` + gray-100 classes → `Card`; swap title `<h2>` + inline status → `CardTitle as="h3"` + separate `Badge`; swap `CustomButton` → `Button`; replace `sejongHospitalBold`/`sejongHospitalLight` spans with `type-body` paragraphs; drop `@/components/ui/button/CustomButton` + `@/utils/fonts/textFonts` imports. Edit toggle behaviour preserved (still controlled via `setIsEditPochaFormOpen` from parent).

## Verification
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] No `sejongHospital*`, no raw grays/hover, no padding override on Card/CardContent (per `feedback_card_no_override`)
- [x] Title uses `type-h3` + `!font-semibold` (per `feedback_type_weight_override`)
- [ ] Manual smoke: edit toggle + ongoing-vs-upcoming visual — requires Vercel `dev` preview

## Scope tag
`[POLISH]` `[NO-TDD]` — matches issue spec

## Notes
- Bailout "`Badge` has no success variant" did NOT fire — DS `Badge` exposes `variant="success"` (matches "진행 중" tone).
- Issue suggested `Button variant="outline" or "secondary"`; DS `Button` only exposes `primary | secondary | tertiary | destructive`, so used `secondary`.

🤖 Autonomous routine — see `AUTONOMOUS_PROTOCOL.md` §5

---
_Generated by [Claude Code](https://claude.ai/code/session_0135oraY1q1wyztf9WYdcsvm)_