### PR TITLE
[Phase 2 / 2.10] PochaInfoFields: deprecated CustomField → DS Form primitives

### DIFF
--- a/src/features/pocha/components/manage/PochaInfoFields.tsx
+++ b/src/features/pocha/components/manage/PochaInfoFields.tsx
@@ -1,4 +1,4 @@
-import CustomField from "@/deprecated-components/shared/CustomField";
+import { Form } from "@umichkisa-ds/form";
 
 interface PochaInfoField {
   value: string;
@@ -11,38 +11,47 @@ interface PochaInfoField {
   errorState: string;
 }
 
-export default function PochaInfoFields({ fields }: { fields: PochaInfoField[] }) {
+interface PochaInfoFieldsProps {
+  fields?: PochaInfoField[];
+}
+
+export default function PochaInfoFields(_props: PochaInfoFieldsProps) {
   return (
-    <div className="flex flex-col gap-6 w-full">
-      {fields.map(
-        (
-          {
-            value,
-            setValue,
-            label,
-            type,
-            placeholder,
-            isError,
-            errorMsg,
-            errorState,
-          },
-          index
-        ) => (
-          <div key={index} className="w-full">
-            <CustomField
-              value={value}
-              setValue={setValue}
-              label={label}
-              required={true}
-              type={type}
-              placeholder={placeholder}
-              isError={isError}
-              errorMsg={errorMsg}
-              errorState={errorState}
-            />
-          </div>
-        )
-      )}
+    <div className="flex w-full flex-col gap-6">
+      <Form.Input
+        name="title"
+        label="포차 이름"
+        type="text"
+        rules={{ required: "포차 제목을 입력해주세요." }}
+      />
+      <Form.Input
+        name="description"
+        label="포차 설명"
+        type="text"
+        rules={{ required: "포차 설명을 입력해주세요." }}
+      />
+      <Form.DatePicker
+        name="startDate"
+        label="시작 날짜"
+        rules={{ required: "유효한 시작 날짜를 입력해주세요." }}
+      />
+      <Form.Input
+        name="startTime"
+        label="시작 시간"
+        type="time"
+        rules={{ required: "유효한 시작 시간을 입력해주세요." }}
+      />
+      <Form.DatePicker
+        name="endDate"
+        label="종료 날짜"
+        rules={{ required: "유효한 종료 날짜를 입력해주세요." }}
+      />
+      <Form.Input
+        name="endTime"
+        label="종료 시간"
+        type="time"
+        rules={{ required: "유효한 종료 시간을 입력해주세요." }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Closes #96

## Summary
Replace deprecated `CustomField` usages inside `PochaInfoFields` with DS form primitives (`Form.Input` for text/time, `Form.DatePicker` for dates). Each field is registered under a named key (`title`, `description`, `startDate`, `startTime`, `endDate`, `endTime`) and declares RHF-native `rules` inline. No zod. Lane 2.11 wires the RHF `<Form>` provider + submit; this lane only migrates the field components.

## Changes
- `src/features/pocha/components/manage/PochaInfoFields.tsx`: drop `CustomField` import; render six DS-form fields by name (matches the locked names in `plan.md` §2.10); keep the legacy `fields?: PochaInfoField[]` prop declaration (unused at runtime) so `PochaForm.tsx`'s current call site still typechecks until lane 2.11 rewrites it.

## Verification
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] No `CustomField` import, no `@/deprecated-components/shared/*` import in file
- [x] All 6 fields render via DS form primitives
- [x] Standalone compilation — lane 2.11 supplies the `<Form>` provider

## Scope tag
`[POLISH]` `[NO-TDD]` — matches issue spec

## Notes
- Time fields use `Form.Input type="time"` — DS does not ship a `TimePicker` (matches the fallback the issue enumerates; no bailout required).
- Cross-field validation (end-datetime > start-datetime) is deliberately left to lane 2.11 per the issue: "lane 2.11 owns cross-field".
- **Runtime impact before lane 2.11 merges:** `PochaForm` renders `PochaInfoFields` outside a `<Form>` provider, so the DS form inputs will throw at runtime. This matches the lane's stated scope ("Component compiles standalone; full integration happens in lane 2.11"). Rollback plan: revert this PR if 2.11 slips beyond the current dev window.

🤖 Autonomous routine — see `AUTONOMOUS_PROTOCOL.md` §5

---
_Generated by [Claude Code](https://claude.ai/code/session_0135oraY1q1wyztf9WYdcsvm)_