### PR TITLE
[Phase 2 / 2.12] PochaMenuFields: section header + empty state retokenize

### DIFF
--- a/src/features/pocha/components/manage/PochaMenuFields.tsx
+++ b/src/features/pocha/components/manage/PochaMenuFields.tsx
@@ -1,14 +1,10 @@
-import React from "react";
-import {
-  sejongHospitalBold,
-  sejongHospitalLight,
-} from "@/utils/fonts/textFonts";
-import { useState } from "react";
-import PochaMenuItemForm from "./PochaMenuItemForm";
+import React, { useState } from "react";
+import { Alert, Button } from "@umichkisa-ds/web";
+
 import { usePochaManage } from "../../contexts/PochaManageContext";
+import PochaMenuItemForm from "./PochaMenuItemForm";
 import PochaMenuItemList from "./PochaMenuItemList";
-import { CustomButton } from "@/components/ui/button";
-import ErrorDisplay from "@/deprecated-components/shared/ErrorDisplay";
+
 export default function PochaMenuFields() {
   const [isItemFormOpen, setIsItemFormOpen] = useState<boolean>(false);
   const { menus } = usePochaManage();
@@ -20,26 +16,20 @@ export default function PochaMenuFields() {
   const handleItemFormClose = () => {
     setIsItemFormOpen(false);
   };
+
   return (
     <div>
-      <div className="flex items-center justify-between mb-4">
-        <h2
-          className={`flex items-start gap-1
-      ${sejongHospitalBold.className} text-xl`}
-        >
-          메뉴
-        </h2>
-        <CustomButton
-          text="추가하기"
-          onClick={handleItemAddButtonClick}
-          className={`${sejongHospitalBold.className}`}
-        />
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="type-h3 !font-semibold">메뉴</h2>
+        <Button variant="secondary" onClick={handleItemAddButtonClick}>
+          추가하기
+        </Button>
       </div>
 
       {menus.length > 0 ? (
         <PochaMenuItemList />
       ) : (
-        <ErrorDisplay text="최소 1개의 메뉴를 추가해주세요." state="error" />
+        <Alert variant="warning">최소 1개의 메뉴를 추가해주세요.</Alert>
       )}
       {isItemFormOpen && (
         <PochaMenuItemForm closeItemForm={handleItemFormClose} mode="create" />


### PR DESCRIPTION
Closes #98

## Summary
Retokenize `PochaMenuFields` onto DS primitives: `메뉴` section header becomes `type-h3` + `!font-semibold`, the empty-state `ErrorDisplay` becomes a DS `Alert variant="warning"`, and the `추가하기` `CustomButton` becomes a DS `Button variant="secondary"`. Add-button behavior preserved — still opens `PochaMenuItemForm` in create mode.

## Changes
- `src/features/pocha/components/manage/PochaMenuFields.tsx`: drop `sejongHospital*` / `CustomButton` / `ErrorDisplay` imports; `<h2>` uses `type-h3 !font-semibold` per `feedback_type_weight_override`; empty state renders via DS `Alert variant="warning"`; add-button uses DS `Button`.

## Verification
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] No `sejongHospital*`, no `ErrorDisplay` import, no `CustomButton` import
- [x] Add-button opens menu-item form (behavior preserved)

## Scope tag
`[POLISH]` `[NO-TDD]` — matches issue spec

## Notes
- `Alert variant="warning"` chosen over `info` — the original copy `"최소 1개의 메뉴를 추가해주세요."` is a required-field message (validation), matching warning semantics.
- Did not touch `PochaMenuItemList` (lane 2.13) or `PochaMenuItemForm` (lanes 2.14–2.16).

🤖 Autonomous routine — see `AUTONOMOUS_PROTOCOL.md` §5

---
_Generated by [Claude Code](https://claude.ai/code/session_0135oraY1q1wyztf9WYdcsvm)_