### PR TITLE
[Phase 2 / 2.13] PochaMenuItemList: Card + IconButton + delete Dialog

### DIFF
--- a/src/features/pocha/components/manage/PochaMenuItemList.tsx
+++ b/src/features/pocha/components/manage/PochaMenuItemList.tsx
@@ -1,33 +1,44 @@
 import React, { useState } from "react";
-import { usePochaManage } from "../../contexts/PochaManageContext";
-import { CustomButton, CustomImageButton } from "@/components/ui/button";
 import {
-  sejongHospitalBold,
-  sejongHospitalLight,
-} from "@/utils/fonts/textFonts";
-import { PencilIcon, TrashcanIcon } from "@/components/ui/icon";
+  Button,
+  Card,
+  CardContent,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+  IconButton,
+} from "@umichkisa-ds/web";
+
 import { MenuItemRaw } from "@/types/pocha";
+
+import { usePochaManage } from "../../contexts/PochaManageContext";
 import PochaMenuItemForm from "./PochaMenuItemForm";
-import Image from "next/image";
-import { getMenuImagePath } from "../../utils/getImagePath";
 
 export default function PochaMenuItemList() {
   const { menus, setMenus } = usePochaManage();
   const [isEditFormOpen, setIsEditFormOpen] = useState(false);
   const [editingMenu, setEditingMenu] = useState<MenuItemRaw | null>(null);
-
-  const onDelete = (nameEngToDelete: string, nameKor: string) => {
-    if (window.confirm(`정말 ${nameKor}을(를) 삭제하시겠습니까?`)) {
-      const updatedMenus = menus.filter(
-        (menu) => menu.nameEng !== nameEngToDelete
-      );
-      setMenus(updatedMenus);
-    }
-  };
+  const [deletingMenu, setDeletingMenu] = useState<MenuItemRaw | null>(null);
 
   const onEdit = (menu: MenuItemRaw) => {
     setEditingMenu(menu);
     setIsEditFormOpen(true);
+  };
+
+  const onRequestDelete = (menu: MenuItemRaw) => {
+    setDeletingMenu(menu);
+  };
+
+  const onConfirmDelete = () => {
+    if (!deletingMenu) return;
+    setMenus(menus.filter((menu) => menu.nameEng !== deletingMenu.nameEng));
+    setDeletingMenu(null);
+  };
+
+  const handleDeleteDialogChange = (open: boolean) => {
+    if (!open) setDeletingMenu(null);
   };
 
   const handleItemFormClose = () => {
@@ -35,85 +46,81 @@ export default function PochaMenuItemList() {
     setEditingMenu(null);
   };
 
-  // getMenuImagePath(menu.menuID)
   return (
     <div className="flex flex-col gap-4">
       {menus.map((menu) => (
-        <div
-          key={menu.nameEng}
-          className="flex flex-row gap-6
-         bg-gray-100 p-4 rounded-lg hover:bg-gray-200 transition-colors"
-        >
-          {/* <figure className="relative h-[6rem] w-[6rem] items-center flex-shrink-0">
-            <Image
-              src={getMenuImagePath(menu?.menuID)}
-              alt={menu.nameEng}
-              fill
-              className="rounded-[15px] border-gray-300 shadow-md object-cover"
-            />
-          </figure> */}
-          <div
-            className={`flex flex-col ${sejongHospitalBold.className} gap-2 w-full
-          `}
-          >
-            <div className="flex justify-between items-center">
-              <h3 className="text-lg">
-                {menu.nameKor} ({menu.nameEng})
-              </h3>
-              <div className="flex items-center">
-                <CustomImageButton
-                  text="수정하기"
-                  type="tertiary"
-                  onClick={() => onEdit(menu)}
-                  icon={<PencilIcon color="gray" />}
-                  forSubmit={false}
+        <Card key={menu.nameEng}>
+          <CardContent>
+            <div className="flex flex-row gap-6">
+              {/* <figure className="relative h-[6rem] w-[6rem] items-center flex-shrink-0">
+                <Image
+                  src={getMenuImagePath(menu?.menuID)}
+                  alt={menu.nameEng}
+                  fill
+                  className="rounded-[15px] border-gray-300 shadow-md object-cover"
                 />
-                <CustomImageButton
-                  text="삭제하기"
-                  type="tertiary"
-                  onClick={() => onDelete(menu.nameEng, menu.nameKor)}
-                  icon={<TrashcanIcon color="gray" />}
-                  forSubmit={false}
-                />
-              </div>
-            </div>
+              </figure> */}
+              <div className="flex w-full flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <h3 className="type-h3 !font-semibold">
+                    {menu.nameKor} ({menu.nameEng})
+                  </h3>
+                  <div className="flex items-center gap-1">
+                    <IconButton
+                      icon="pencil"
+                      variant="tertiary"
+                      size="sm"
+                      aria-label="수정하기"
+                      onClick={() => onEdit(menu)}
+                    />
+                    <IconButton
+                      icon="trash-2"
+                      variant="tertiary"
+                      size="sm"
+                      aria-label="삭제하기"
+                      onClick={() => onRequestDelete(menu)}
+                    />
+                  </div>
+                </div>
 
-            <div className="flex flex-col gap-2 text-base">
-              <span>
-                카테고리:{" "}
-                <span className={`${sejongHospitalLight.className}`}>
-                  {menu.category}
-                </span>
-              </span>
-              <span>
-                가격:{" "}
-                <span className={`${sejongHospitalLight.className}`}>
-                  ${menu.price?.toLocaleString()}
-                </span>
-              </span>
-              <span>
-                재고:{" "}
-                <span className={`${sejongHospitalLight.className}`}>
-                  {menu.stock}개
-                </span>
-              </span>
-              <div className="flex gap-4">
-                <span>
-                  즉시 준비:{" "}
-                  <span className={`${sejongHospitalLight.className}`}>
-                    {menu.isImmediatePrep ? "예" : "아니오"}
-                  </span>
-                </span>
-                <span>
-                  연령 확인:{" "}
-                  <span className={`${sejongHospitalLight.className}`}>
-                    {menu.ageCheckRequired ? "필요" : "불필요"}
-                  </span>
-                </span>
+                <div className="flex flex-col gap-2 type-body">
+                  <p>
+                    <span>카테고리: </span>
+                    <span className="text-muted-foreground">
+                      {menu.category}
+                    </span>
+                  </p>
+                  <p>
+                    <span>가격: </span>
+                    <span className="text-muted-foreground">
+                      ${menu.price?.toLocaleString()}
+                    </span>
+                  </p>
+                  <p>
+                    <span>재고: </span>
+                    <span className="text-muted-foreground">
+                      {menu.stock}개
+                    </span>
+                  </p>
+                  <div className="flex gap-4">
+                    <p>
+                      <span>즉시 준비: </span>
+                      <span className="text-muted-foreground">
+                        {menu.isImmediatePrep ? "예" : "아니오"}
+                      </span>
+                    </p>
+                    <p>
+                      <span>연령 확인: </span>
+                      <span className="text-muted-foreground">
+                        {menu.ageCheckRequired ? "필요" : "불필요"}
+                      </span>
+                    </p>
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
+          </CardContent>
+        </Card>
       ))}
 
       {isEditFormOpen && (
@@ -123,6 +130,31 @@ export default function PochaMenuItemList() {
           initialData={editingMenu}
         />
       )}
+
+      <Dialog
+        open={deletingMenu !== null}
+        onOpenChange={handleDeleteDialogChange}
+      >
+        <DialogContent size="sm">
+          <DialogTitle>메뉴 삭제</DialogTitle>
+          <DialogDescription>
+            {deletingMenu
+              ? `정말 ${deletingMenu.nameKor}을(를) 삭제하시겠습니까?`
+              : ""}
+          </DialogDescription>
+          <DialogFooter>
+            <Button
+              variant="secondary"
+              onClick={() => setDeletingMenu(null)}
+            >
+              취소
+            </Button>
+            <Button variant="destructive" onClick={onConfirmDelete}>
+              삭제
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
Closes #99

## Summary
Retokenize `PochaMenuItemList` onto DS primitives: bespoke gray-100 row → DS `Card` + `CardContent`; edit/delete `CustomImageButton` → DS `IconButton` (variant `tertiary`, size `sm`, icons `pencil` / `trash-2`); `window.confirm` delete flow → DS `Dialog` with destructive confirm / secondary cancel; body typography tokenized (`type-h3`, `type-body`, `text-muted-foreground`).

## Changes
- `src/features/pocha/components/manage/PochaMenuItemList.tsx`:
  - swap outer row `<div>` + gray-100 classes → `Card` + `CardContent`
  - introduce `deletingMenu` state + `Dialog` (title `메뉴 삭제`, description `정말 {nameKor}을(를) 삭제하시겠습니까?`, destructive confirm / secondary cancel)
  - drop legacy `CustomImageButton` + `PencilIcon` / `TrashcanIcon` imports; use DS `IconButton` with `icon="pencil"` / `icon="trash-2"` and explicit `aria-label`s
  - drop `sejongHospitalBold` / `sejongHospitalLight` imports + body usage
  - keep the commented-out image `<figure>` block verbatim — lane 2.16 owns FileUpload integration per issue non-goals
  - drop now-unused `Image` + `getMenuImagePath` imports

## Verification
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] No `window.confirm`, no `CustomImageButton`, no `sejongHospital*`
- [x] Delete dialog uses destructive variant with Korean title/body
- [x] Edit flow unchanged — still opens `PochaMenuItemForm` with `mode="update"` + `initialData`
- [x] Commented-out image `<figure>` block preserved (lane 2.16)

## Scope tag
`[POLISH]` `[NO-TDD]` — matches issue spec

## Notes
- Bailout triggers did NOT fire: DS `Button` sibling `IconButton` exists and accepts the requested icons from the registry (`pencil`, `trash-2`), so no `ds-fix-during-migration` was required. No icon registry additions or patch bump needed.

🤖 Autonomous routine — see `AUTONOMOUS_PROTOCOL.md` §5

---
_Generated by [Claude Code](https://claude.ai/code/session_0135oraY1q1wyztf9WYdcsvm)_