### PR TITLE
[Phase 2 / 2.7] PreviousPochaList + Summary redesign + menu-detail Dialog + page reorder

### DIFF
--- a/src/app/(pocha)/pocha/manage/page.tsx
+++ b/src/app/(pocha)/pocha/manage/page.tsx
@@ -72,7 +72,6 @@ function PochaManagePageContent() {
 
   return (
     <>
-      <PreviousPochaList />
       {noPochaAvailable && (
         <div className="flex flex-col w-full gap-2">
           <CustomButton
@@ -96,6 +95,9 @@ function PochaManagePageContent() {
           )}
         </div>
       )}
+      <div className="mt-10">
+        <PreviousPochaList />
+      </div>
     </>
   );
 }

--- a/src/features/pocha/components/manage/PreviosPochaSummary.tsx
+++ b/src/features/pocha/components/manage/PreviosPochaSummary.tsx
@@ -1,11 +1,18 @@
 // PreviousPochaSummary.tsx
-import { useEffect, useState } from 'react';
-import { getPochaMenu } from '@/apis/pocha/queries';
-import { PochaInfoWithoutStatus } from '@/types/pocha';
 import {
-  sejongHospitalBold,
-  sejongHospitalLight,
-} from '@/utils/fonts/textFonts';
+  Card,
+  CardDescription,
+  CardTitle,
+  Icon,
+  cn,
+} from "@umichkisa-ds/web";
+
+import { PochaInfoWithoutStatus } from "@/types/pocha";
+import {
+  formatDateInTz,
+  formatTimeInTz,
+  tzAbbreviation,
+} from "@/utils/formats/timezone";
 
 interface PreviousPochaSummaryProps {
   pochaInfo: PochaInfoWithoutStatus;
@@ -18,58 +25,45 @@ function PreviousPochaSummary({
   onClick,
   isSelected,
 }: PreviousPochaSummaryProps) {
-  const [menuList, setMenuList] = useState<any[]>([]);
-  const [isLoadingMenu, setIsLoadingMenu] = useState(true);
+  const start = pochaInfo.startDate;
+  const end = pochaInfo.endDate;
+  const sameDay = formatDateInTz(start) === formatDateInTz(end);
+  const tz = tzAbbreviation(start);
+  const dateLine = sameDay
+    ? `${formatDateInTz(start)} · ${formatTimeInTz(start)} → ${formatTimeInTz(end)} (${tz})`
+    : `${formatDateInTz(start)} ${formatTimeInTz(start)} → ${formatDateInTz(end)} ${formatTimeInTz(end)} (${tz})`;
 
-  useEffect(() => {
-    const fetchMenu = async () => {
-      try {
-        const menus = await getPochaMenu(pochaInfo.pochaID);
-        const allMenus =
-          menus?.flatMap((category: any) => category.menusList) || [];
-        setMenuList(allMenus);
-      } catch (error) {
-        console.error('Failed to fetch menu:', error);
-        setMenuList([]);
-      } finally {
-        setIsLoadingMenu(false);
-      }
-    };
-
-    fetchMenu();
-  }, [pochaInfo.pochaID]);
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!onClick) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClick();
+    }
+  };
 
   return (
-    <div
-      className={`border rounded-lg p-4 shadow-sm transition-all ${
-        onClick ? 'cursor-pointer hover:shadow-md hover:border-blue-500' : ''
-      } ${isSelected ? 'border-blue-500 bg-blue-50' : 'border-gray-200'}`}
+    <Card
+      hoverable
       onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        "cursor-pointer",
+        isSelected && "bg-brand-accent-subtle border-brand-primary"
+      )}
     >
-      <h3 className={`${sejongHospitalBold.className} text-xl mb-2`}>
-        {pochaInfo.title}
-      </h3>
-
-      <p className={`${sejongHospitalLight.className} text-gray-600 mb-2`}>
-        {pochaInfo.description}
-      </p>
-
-      <div className='text-sm text-gray-500 mb-2'>
-        <div>시작: {new Date(pochaInfo.startDate).toLocaleString('ko-KR')}</div>
-        <div>종료: {new Date(pochaInfo.endDate).toLocaleString('ko-KR')}</div>
+      <CardTitle as="h3">{pochaInfo.title}</CardTitle>
+      {pochaInfo.description && (
+        <CardDescription className="line-clamp-2">
+          {pochaInfo.description}
+        </CardDescription>
+      )}
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <Icon name="calendar" size="sm" />
+        <span className="type-body-sm">{dateLine}</span>
       </div>
-
-      <div className={`${sejongHospitalBold.className} text-sm`}>
-        메뉴:{' '}
-        <span className={`${sejongHospitalLight.className}`}>
-          {isLoadingMenu
-            ? '로딩 중...'
-            : menuList.length > 0
-            ? menuList.map((menu) => menu.nameKor).join(', ')
-            : '메뉴 없음'}
-        </span>
-      </div>
-    </div>
+    </Card>
   );
 }
 

--- a/src/features/pocha/components/manage/PreviousPochaDetailDialog.tsx
+++ b/src/features/pocha/components/manage/PreviousPochaDetailDialog.tsx
@@ -1,0 +1,162 @@
+import {
+  Alert,
+  Badge,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  Divider,
+  Icon,
+  LoadingSpinner,
+} from "@umichkisa-ds/web";
+
+import useAdmin from "@/lib/next-auth/useAdmin";
+import useMenu from "@/features/pocha/hooks/useMenu";
+import { convertMenuByCategoryToRawList } from "@/features/pocha/utils/convertMenuType";
+import {
+  MenuByCategory,
+  MenuItemRaw,
+  PochaInfoWithoutStatus,
+} from "@/types/pocha";
+import {
+  formatDateInTz,
+  formatTimeInTz,
+  tzAbbreviation,
+} from "@/utils/formats/timezone";
+
+interface PreviousPochaDetailDialogProps {
+  pocha: PochaInfoWithoutStatus | null;
+  onClose: () => void;
+}
+
+export default function PreviousPochaDetailDialog({
+  pocha,
+  onClose,
+}: PreviousPochaDetailDialogProps) {
+  const open = pocha !== null;
+  const { token } = useAdmin();
+
+  // useMenu already guards with `pochaID && token ? [key] : null`,
+  // so a 0 or empty token won't fetch.
+  const { menuList, status } = useMenu(pocha?.pochaID ?? 0, token ?? "");
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent size="md">
+        {pocha && (
+          <>
+            <DialogTitle className="!font-semibold">
+              {pocha.title}
+            </DialogTitle>
+            {pocha.description && (
+              <DialogDescription>{pocha.description}</DialogDescription>
+            )}
+
+            <Divider className="my-4" />
+
+            <div className="grid grid-cols-2 gap-4">
+              <DateBlock label="시작" date={pocha.startDate} />
+              <DateBlock label="종료" date={pocha.endDate} />
+            </div>
+
+            <Divider className="my-4" />
+
+            <div className="flex flex-col gap-3">
+              <p className="type-body-sm text-muted-foreground">메뉴</p>
+              <MenuSection status={status} menuList={menuList} />
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DateBlock({
+  label,
+  date,
+}: {
+  label: string;
+  date: Date | string;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <Icon name="calendar" size="sm" />
+        <span className="type-body-sm">{label}</span>
+      </div>
+      <p className="type-h4 !font-semibold text-foreground">
+        {formatDateInTz(date)}
+      </p>
+      <p className="type-body-sm text-muted-foreground">
+        {formatTimeInTz(date)} ({tzAbbreviation(date)})
+      </p>
+    </div>
+  );
+}
+
+function MenuSection({
+  status,
+  menuList,
+}: {
+  status: string;
+  menuList: MenuByCategory[] | undefined;
+}) {
+  if (status === "loading") {
+    return (
+      <div className="flex justify-center py-6">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return <Alert variant="error">메뉴를 불러오지 못했습니다.</Alert>;
+  }
+
+  const items = convertMenuByCategoryToRawList(menuList ?? []);
+  if (items.length === 0) {
+    return <Alert variant="info">등록된 메뉴가 없습니다.</Alert>;
+  }
+
+  const immediatePrepMenus = items.filter((m) => m.isImmediatePrep);
+  const cookingMenus = items.filter((m) => !m.isImmediatePrep);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {immediatePrepMenus.length > 0 && (
+        <MenuGroup label="즉시 제공" items={immediatePrepMenus} />
+      )}
+      {cookingMenus.length > 0 && (
+        <MenuGroup label="조리 필요" items={cookingMenus} />
+      )}
+    </div>
+  );
+}
+
+function MenuGroup({
+  label,
+  items,
+}: {
+  label: string;
+  items: MenuItemRaw[];
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="type-body-sm text-muted-foreground">
+        {label} · {items.length}
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {items.map((menu) => (
+          <Badge
+            key={menu.menuID ?? menu.nameKor}
+            variant="outline"
+            size="md"
+          >
+            {menu.nameKor}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/pocha/components/manage/PreviousPochaList.tsx
+++ b/src/features/pocha/components/manage/PreviousPochaList.tsx
@@ -1,12 +1,12 @@
 // PreviousPochaList.tsx
-import { HorizontalDivider } from '@/components/ui/divider';
-import { sejongHospitalBold } from '@/utils/fonts/textFonts';
-import { useMemo } from 'react';
-import useSWR from 'swr';
-import { fetcher } from '@/lib/swr/fetchers';
-import React from 'react';
-import { PochaInfoWithoutStatus } from '@/types/pocha';
-import PreviousPochaSummary from './PreviosPochaSummary';
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+import { Alert, Card, Skeleton } from "@umichkisa-ds/web";
+
+import { fetcher } from "@/lib/swr/fetchers";
+import { PochaInfoWithoutStatus } from "@/types/pocha";
+import PreviousPochaSummary from "./PreviosPochaSummary";
+import PreviousPochaDetailDialog from "./PreviousPochaDetailDialog";
 
 interface PreviousPochaListProps {
   onSelectPocha?: (pocha: PochaInfoWithoutStatus) => void;
@@ -18,9 +18,12 @@ function PreviousPochaList({
   selectedPochaId,
 }: PreviousPochaListProps) {
   const dateIso = useMemo(
-    () => new Date().toISOString().split('.')[0],
+    () => new Date().toISOString().split(".")[0],
     []
   );
+
+  const [detailPocha, setDetailPocha] =
+    useState<PochaInfoWithoutStatus | null>(null);
 
   const {
     data: rawList,
@@ -41,46 +44,63 @@ function PreviousPochaList({
     [rawList]
   );
 
-  if (isLoading) {
-    return <></>;
-  }
-
-  if (error) {
-    return (
-      <div className='flex flex-col w-full gap-6 items-center justify-center p-8'>
-        <p className='text-red-500'>
-          이전 포차 정보를 불러오는데 실패했습니다.
-        </p>
-        <p className='text-sm text-gray-500'>
-          {error instanceof Error
-            ? error.message
-            : 'An unexpected error occurred.'}
-        </p>
-      </div>
-    );
-  }
+  const count = previousPochaList?.length ?? 0;
+  const showDialog = !onSelectPocha;
 
   return (
-    <div className='flex flex-col w-full gap-6'>
-      <h2 className={`${sejongHospitalBold.className} text-2xl`}>
-        이전 포차 목록
-      </h2>
+    <section className="flex flex-col w-full gap-4">
+      <div className="flex items-center gap-2">
+        <h2 className="type-h2 !font-semibold text-foreground">
+          이전 포차 목록
+        </h2>
+        {!isLoading && !error && previousPochaList && (
+          <span className="type-caption text-muted-foreground">{count}개</span>
+        )}
+      </div>
 
-      {previousPochaList && previousPochaList.length > 0 ? (
-        previousPochaList.map((pocha) => (
-          <PreviousPochaSummary
-            key={pocha.pochaID}
-            pochaInfo={pocha}
-            onClick={onSelectPocha ? () => onSelectPocha(pocha) : undefined}
-            isSelected={selectedPochaId === pocha.pochaID}
-          />
-        ))
+      {isLoading ? (
+        <div className="flex flex-col gap-3">
+          {[0, 1, 2].map((i) => (
+            <Card key={i} hoverable={false}>
+              <Skeleton className="h-5 w-2/3" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-4 w-1/2 mt-1" />
+            </Card>
+          ))}
+        </div>
+      ) : error ? (
+        <Alert variant="error" title="이전 포차 정보를 불러오지 못했습니다.">
+          {error instanceof Error
+            ? error.message
+            : "잠시 후 다시 시도해주세요."}
+        </Alert>
+      ) : previousPochaList && previousPochaList.length > 0 ? (
+        <div className="flex flex-col gap-3">
+          {previousPochaList.map((pocha) => (
+            <PreviousPochaSummary
+              key={pocha.pochaID}
+              pochaInfo={pocha}
+              onClick={
+                onSelectPocha
+                  ? () => onSelectPocha(pocha)
+                  : () => setDetailPocha(pocha)
+              }
+              isSelected={selectedPochaId === pocha.pochaID}
+            />
+          ))}
+        </div>
       ) : (
-        <p className='text-gray-500'>이전 포차가 없습니다.</p>
+        <Alert variant="info">아직 진행된 포차가 없습니다.</Alert>
       )}
 
-      <HorizontalDivider />
-    </div>
+      {showDialog && (
+        <PreviousPochaDetailDialog
+          pocha={detailPocha}
+          onClose={() => setDetailPocha(null)}
+        />
+      )}
+    </section>
   );
 }
 


### PR DESCRIPTION
Closes #93

## Summary

Lane 2.7 — locked-spec redesign of the previous-pocha list stack on `/pocha/manage`, with a new list-owned menu-detail Dialog, N+1 fix (row drops its per-item menu fetch; Dialog fetches lazily for the clicked row only), and a page reorder so the active `PochaSummary` renders above the previous list.

## Changes

- `src/features/pocha/components/manage/PreviousPochaList.tsx` — rewritten: h2 header + `{count}개` chip, `gap-3` rows (no inter-row divider, no trailing `HorizontalDivider`), skeleton Card loading, Alert error/empty branches, list-owned `detailPocha` state + `PreviousPochaDetailDialog` mount when `!onSelectPocha`.
- `src/features/pocha/components/manage/PreviosPochaSummary.tsx` — rewritten as a clickable DS `Card` (hoverable, `role="button"`, `tabIndex={0}`, keyboard Enter/Space handler). Drops `useState`/`useEffect`/`getPochaMenu` N+1 fetch and all `sejongHospital*` imports. Date-line formatted via `@/utils/formats/timezone` helpers; same-day vs multi-day branching per spec.
- `src/features/pocha/components/manage/PreviousPochaDetailDialog.tsx` (new) — `DialogTitle` (+`!font-semibold`) + optional `DialogDescription`, two-column `DateBlock` grid, `MenuSection` branching on `useMenu(pocha.pochaID, token).status` with `즉시 제공` / `조리 필요` Badge chips.
- `src/app/(pocha)/pocha/manage/page.tsx` — render-order swap only: active branch (new-pocha button or `PochaSummary` + edit form) renders first; `<PreviousPochaList />` renders last, wrapped in `<div className="mt-10">`. Legacy `ui/` imports (`CustomButton`, `LoadingSpinner`, `NotAuthorized`) are out of scope per spec — deferred to lane 2.17.

## Verification

- [x] `npx tsc --noEmit --ignoreDeprecations 6.0` — 0 errors in `src/**` (DS `@umichkisa-ds/web` + new files typecheck clean).
- [x] `next build` — `✓ Compiled successfully` and `Linting and checking validity of types` pass; only pre-existing unrelated warnings (no new ones in the touched files). Page-data collection then fails on `/api/attach-payment-method` with `Neither apiKey nor config.authenticator provided` (missing Stripe env in sandbox) — pre-existing, unrelated to this lane.
- [x] ds-client-review — see "Notes" below.

## Scope tag

`[REDESIGN]` `[NO-TDD]` — matches issue spec.

## Deviations from original

- `PreviousPochaList` header color: added `text-foreground` to the h2 (paired per the rule "Pair an explicit color token with every `type-*` class" — DS_CLIENT_USAGE.md).
- No `DialogHeader` wrapper in `PreviousPochaDetailDialog` — DS Dialog doesn't export `DialogHeader`; using `DialogTitle` + `DialogDescription` siblings directly (per DS surface area).
- `MenuSection` `status` prop typed as `string` (not `"loading" | "error" | "success"`) — `useMenu` returns `status` inferred as `string` from its ternary. Internal discriminator only.

## Notes

- The review agent flagged `type-h2 !font-semibold`, `DialogTitle !font-semibold`, and `type-h4 !font-semibold` as typography overrides. These are **per the issue's locked spec** ("Header: `<h2>` type-h2 !font-semibold", "DialogTitle (type-h3 !font-semibold)", "DateBlock date: type-h4 !font-semibold") and match the established phase-2 pattern in `PochaSummary.tsx` (already on `dev`) per memory `feedback_type_weight_override`. Flagging here for reviewer awareness, not blocking.
- `DialogTitle` has `type-h3 text-foreground` baked in — the spec said "if className reject is encountered, drop override, use defaults (acceptable, note in PR)". `!font-semibold` is the only override applied and it took successfully; no sizing override needed.
- `useMenu(pocha?.pochaID ?? 0, token ?? "")` — `useMenu`'s internal SWR key is `pochaID && token ? [key] : null`, so 0 + empty string safely no-op (no unwanted fetch). The guard is within the hook.

## Files touched

```
src/app/(pocha)/pocha/manage/page.tsx             +3 -1
src/features/pocha/components/manage/PreviosPochaSummary.tsx     (rewrite)
src/features/pocha/components/manage/PreviousPochaList.tsx       (rewrite)
src/features/pocha/components/manage/PreviousPochaDetailDialog.tsx (new)
```

No files outside the issue's `## Files` list were touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UktPhwEoAj1zsDhLpxJ8sc)_