### PR TITLE
Refactor SectionImage className to use Tailwind opacity syntax

### DIFF
--- a/src/features/info-page/components/SectionImage.jsx
+++ b/src/features/info-page/components/SectionImage.jsx
@@ -26,8 +26,8 @@ export default function SectionImage({
 
       {/* Cover */}
       <div
-        className="absolute flex flex-col gap-2 justify-center items-center w-full h-full 
-          bg-[#2F2F2F] bg-opacity-40 hover:bg-opacity-10 px-4 transition-all duration-300 ease-in-out cursor-pointer"
+        className="absolute flex flex-col gap-2 justify-center items-center w-full h-full
+          bg-[#2F2F2F]/40 hover:bg-[#2F2F2F]/10 px-4 transition-all duration-300 ease-in-out cursor-pointer"
       >
         {name.split("\n").map((line, index) => (
           <span


### PR DESCRIPTION
## Description

Refactored the background opacity styling in the SectionImage component to use Tailwind CSS's modern opacity syntax (`bg-[#2F2F2F]/40`) instead of the older `bg-opacity-*` utility approach. This change improves code consistency with current Tailwind best practices and reduces the number of utility classes needed.

**Changes:**
- Updated `bg-[#2F2F2F] bg-opacity-40` to `bg-[#2F2F2F]/40`
- Updated `hover:bg-opacity-10` to `hover:bg-[#2F2F2F]/10`
- Fixed line break formatting for better readability

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Notes

This is a refactoring change that maintains identical visual behavior while modernizing the Tailwind CSS syntax. No functional changes to the component.

https://claude.ai/code/session_018e8RSMk3s1ZzbeU8aRxZ3J