### PR TITLE
refactor(home-sponsor): replace orphaned section_title with DS type-h3

### DIFF
--- a/src/app/home.css
+++ b/src/app/home.css
@@ -1,9 +1,5 @@
 @reference "./globals.css";
 
-.section_title {
-  @apply text-lg sm:text-xl lg:text-2xl;
-}
-
 .react-multi-carousel-list {
   padding: 0rem 0 2rem 0;
 }

--- a/src/features/home-sponsor/components/QuickLinks.tsx
+++ b/src/features/home-sponsor/components/QuickLinks.tsx
@@ -37,7 +37,7 @@ export default function QuickLinks() {
       className={`w-full
     flex flex-col gap-4 ${sejongHospitalBold.className}`}
     >
-      <h2 className="section_title">Quick Links</h2>
+      <h2 className="type-h3">Quick Links</h2>
 
       <Carousel
         responsive={responsive}

--- a/src/features/home-sponsor/components/SchoolCalendar.jsx
+++ b/src/features/home-sponsor/components/SchoolCalendar.jsx
@@ -75,7 +75,7 @@ export default function SchoolCalendar() {
       className={`${sejongHospitalBold.className} w-full flex flex-col 
       gap-2 md:gap-6`}
     >
-      <h2 className="section_title">Calendar</h2>
+      <h2 className="type-h3">Calendar</h2>
       <div className="flex flex-col lg:flex-row gap-6">
         <div className="w-full text-xs lg:text-sm hidden md:block">
           <FullCalendar

--- a/src/features/home-sponsor/components/SponsorCarousel.tsx
+++ b/src/features/home-sponsor/components/SponsorCarousel.tsx
@@ -42,7 +42,7 @@ export default function SponsorCarousel() {
     flex flex-col gap-4 ${sejongHospitalBold.className}`}
     >
       <div className="flex flex-col gap-1">
-        <span className="section_title">Sponsors</span>
+        <span className="type-h3">Sponsors</span>
         <p className={`${sejongHospitalLight.className} text-base md:text-lg`}>
           Proudly supported by leading organizations.
         </p>


### PR DESCRIPTION
## Summary

- The `.section_title` rule lived in `src/app/home.css`, which was no longer imported anywhere after the `@umichkisa-ds/web` migration. As a result, the three home-page section headers (Sponsors, Calendar, Quick Links) rendered at default body size instead of the intended responsive heading scale.
- Swap the className to the design-system typography token `type-h3` (1.125rem mobile / 1.25rem md+, pretendard, weight 600) in `SponsorCarousel.tsx`, `SchoolCalendar.jsx`, and `QuickLinks.tsx`.
- Drop the now-dead `.section_title` rule from `src/app/home.css`.

## Test plan

- [ ] Load `/` and confirm "Sponsors", "Calendar", and "Quick Links" headers all render at the larger DS heading size at base, md, and lg breakpoints.
- [ ] `npx tsc --noEmit` passes.
- [ ] `npm run lint` produces no new warnings.

https://claude.ai/code/session_018e8RSMk3s1ZzbeU8aRxZ3J

---
_Generated by [Claude Code](https://claude.ai/code/session_018e8RSMk3s1ZzbeU8aRxZ3J)_