### PR TITLE
refactor(home-sponsor): bump section headers to type-h2 + sejong bold

### DIFF
--- a/src/features/home-sponsor/components/QuickLinks.tsx
+++ b/src/features/home-sponsor/components/QuickLinks.tsx
@@ -37,7 +37,7 @@ export default function QuickLinks() {
       className={`w-full
     flex flex-col gap-4 ${sejongHospitalBold.className}`}
     >
-      <h2 className="type-h3">Quick Links</h2>
+      <h2 className="type-h2 !font-sejong-bold">Quick Links</h2>
 
       <Carousel
         responsive={responsive}

--- a/src/features/home-sponsor/components/SchoolCalendar.jsx
+++ b/src/features/home-sponsor/components/SchoolCalendar.jsx
@@ -75,7 +75,7 @@ export default function SchoolCalendar() {
       className={`${sejongHospitalBold.className} w-full flex flex-col 
       gap-2 md:gap-6`}
     >
-      <h2 className="type-h3">Calendar</h2>
+      <h2 className="type-h2 !font-sejong-bold">Calendar</h2>
       <div className="flex flex-col lg:flex-row gap-6">
         <div className="w-full text-xs lg:text-sm hidden md:block">
           <FullCalendar

--- a/src/features/home-sponsor/components/SponsorCarousel.tsx
+++ b/src/features/home-sponsor/components/SponsorCarousel.tsx
@@ -42,7 +42,7 @@ export default function SponsorCarousel() {
     flex flex-col gap-4 ${sejongHospitalBold.className}`}
     >
       <div className="flex flex-col gap-1">
-        <span className="type-h3">Sponsors</span>
+        <span className="type-h2 !font-sejong-bold">Sponsors</span>
         <p className={`${sejongHospitalLight.className} text-base md:text-lg`}>
           Proudly supported by leading organizations.
         </p>


### PR DESCRIPTION
## Summary

Builds on #129 (type-h3 swap, already merged). Bumps the three home-page section headers (Sponsors, Calendar, Quick Links) one step larger and switches the typeface to SejongHospital Bold:

- `type-h3` -> `type-h2`: 1.25rem mobile / 1.375rem md / 1.5rem lg (vs h3's 1.125 -> 1.25)
- `!font-sejong-bold`: overrides h2's pretendard default with `var(--font-sejong-bold)` via `!important`

## Test plan

- [ ] Load `/` and confirm "Sponsors", "Calendar", "Quick Links" render in SejongHospital Bold and at the larger size at base / md / lg breakpoints.
- [ ] `npx tsc --noEmit` passes.
- [ ] `npm run lint` produces no new warnings.

https://claude.ai/code/session_018e8RSMk3s1ZzbeU8aRxZ3J

---
_Generated by [Claude Code](https://claude.ai/code/session_018e8RSMk3s1ZzbeU8aRxZ3J)_