### PR TITLE
[Phase 3 / 3.1] mocks: pocha dashboard MSW handlers

### DIFF
--- a/src/mocks/fixtures/pocha.ts
+++ b/src/mocks/fixtures/pocha.ts
@@ -1,4 +1,16 @@
-import type { MenuByCategory, PochaInfoWithoutStatus } from "@/types/pocha";
+import type {
+  MenuByCategory,
+  MenuItem,
+  OrderItem,
+  PochaInfoWithoutStatus,
+} from "@/types/pocha";
+// `OrderStatus` is a const enum; under `isolatedModules` we can't import its
+// values cross-module, so the literal strings below are typed via
+// `OrderItem['status']` instead.
+// `OrderItem["status"]` is the const enum `OrderStatus` — its members can't be
+// imported as values under `isolatedModules`. The string literals below are
+// the underlying enum values; cast in `_make` keeps the assignments terse.
+type OrderStatusLiteral = "pending" | "preparing" | "ready" | "closed";
 
 /**
  * Pocha fixtures — seed data for MSW pocha handlers.
@@ -253,3 +265,102 @@ export const mockPochaMenus: Record<number, MenuByCategory[]> = {
     },
   ],
 };
+
+// ORDERS ---------------------------------------------------------------------
+
+/**
+ * Order fixtures for the active pocha (pochaID=1) — used by dashboard handlers.
+ * `nextOrderItemID` (in handler module) is initialized just past
+ * `mockOrderItemIDStart + mockOrderItems.length` so spawn-order ids stay
+ * monotonic. Stock numbers in the embedded `menu` are snapshots at seed time;
+ * subsequent stock mutations affect `menusStore` but not in-flight orders.
+ */
+const _menuByID: Record<number, MenuItem> = (() => {
+  const out: Record<number, MenuItem> = {};
+  for (const group of mockPochaMenus[1]!) {
+    for (const m of group.menusList) out[m.menuID] = { ...m };
+  }
+  return out;
+})();
+
+const _orderers: Array<{ name: string; email: string }> = [
+  { name: "민수", email: "minsoo@umich.edu" },
+  { name: "지영", email: "jiyoung@umich.edu" },
+  { name: "현우", email: "hyunwoo@umich.edu" },
+  { name: "수진", email: "sujin@umich.edu" },
+  { name: "도윤", email: "doyoon@umich.edu" },
+];
+
+export const mockOrderItemIDStart = 1000;
+
+const _make = (
+  i: number,
+  status: OrderStatusLiteral,
+  menuID: number,
+  quantity: number
+): OrderItem => {
+  const orderer = _orderers[i % _orderers.length]!;
+  return {
+    orderItemID: mockOrderItemIDStart + i,
+    status: status as unknown as OrderItem["status"],
+    menu: { ..._menuByID[menuID]! },
+    quantity,
+    ordererName: orderer.name,
+    ordererEmail: orderer.email,
+  };
+};
+
+/**
+ * 25 active (pending/preparing/ready) + 15 closed = 40 fixture orders.
+ * Mix of food + drink + snack across all status buckets so the dashboard
+ * has realistic data for every column on first paint.
+ */
+export const mockOrderItems: OrderItem[] = [
+  // pending — 9 (food + drink + snack)
+  _make(0, "pending", 201, 2), // 떡볶이
+  _make(1, "pending", 101, 1), // 소주
+  _make(2, "pending", 203, 1), // 라면
+  _make(3, "pending", 102, 2), // 맥주
+  _make(4, "pending", 204, 1), // 파전
+  _make(5, "pending", 301, 1), // 새우깡
+  _make(6, "pending", 206, 1), // 김치찌개
+  _make(7, "pending", 103, 3), // 콜라
+  _make(8, "pending", 205, 1), // 계란말이
+
+  // preparing — 8 (food only — drinks skip preparing)
+  _make(9, "preparing", 201, 1),
+  _make(10, "preparing", 202, 2),
+  _make(11, "preparing", 203, 1),
+  _make(12, "preparing", 204, 1),
+  _make(13, "preparing", 205, 2),
+  _make(14, "preparing", 206, 1),
+  _make(15, "preparing", 207, 1),
+  _make(16, "preparing", 201, 1),
+
+  // ready — 8 (food + drinks)
+  _make(17, "ready", 101, 1),
+  _make(18, "ready", 202, 1),
+  _make(19, "ready", 102, 2),
+  _make(20, "ready", 203, 1),
+  _make(21, "ready", 302, 1),
+  _make(22, "ready", 207, 1),
+  _make(23, "ready", 103, 1),
+  _make(24, "ready", 204, 1),
+
+  // closed — 15 (history)
+  _make(25, "closed", 201, 2),
+  _make(26, "closed", 101, 1),
+  _make(27, "closed", 202, 1),
+  _make(28, "closed", 203, 2),
+  _make(29, "closed", 102, 1),
+  _make(30, "closed", 204, 1),
+  _make(31, "closed", 205, 1),
+  _make(32, "closed", 103, 2),
+  _make(33, "closed", 206, 1),
+  _make(34, "closed", 301, 1),
+  _make(35, "closed", 207, 1),
+  _make(36, "closed", 101, 2),
+  _make(37, "closed", 202, 1),
+  _make(38, "closed", 302, 1),
+  _make(39, "closed", 201, 1),
+];

--- a/src/mocks/handlers/__tests__/pocha.test.ts
+++ b/src/mocks/handlers/__tests__/pocha.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { setupServer } from "msw/node";
-import { pochaHandlers, resetPochaStore } from "../pocha";
+import { pochaHandlers, resetOrderStore, resetPochaStore } from "../pocha";
 
 const server = setupServer(...pochaHandlers);
 
@@ -30,6 +30,7 @@ beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => {
   server.resetHandlers();
   resetPochaStore();
+  resetOrderStore();
 });
 afterAll(() => server.close());
 
@@ -183,6 +184,279 @@ describe("MSW pocha handlers", () => {
     it("returns 401 when Authorization header is missing", async () => {
       const res = await fetch("http://localhost/pocha/menu/1/");
       expect(res.status).toBe(401);
+    });
+  });
+});
+
+describe("MSW pocha dashboard handlers", () => {
+  // Active fixture pocha used for all dashboard endpoints.
+  const POCHA_ID = 1;
+
+  describe("GET /pocha/dashboard/:pochaID/ (active orders)", () => {
+    it("returns 200 with { pending, preparing, ready } populated from non-closed fixtures", async () => {
+      const res = await fetch(`http://localhost/pocha/dashboard/${POCHA_ID}/`, {
+        headers: AUTH_HEADER,
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(Array.isArray(body.pending)).toBe(true);
+      expect(Array.isArray(body.preparing)).toBe(true);
+      expect(Array.isArray(body.ready)).toBe(true);
+      // None of the active buckets contain a `closed` item.
+      const all = [...body.pending, ...body.preparing, ...body.ready];
+      expect(all.length).toBeGreaterThan(0);
+      for (const item of all) {
+        expect(item.status).not.toBe("closed");
+        expect(typeof item.orderItemID).toBe("number");
+        expect(typeof item.menu).toBe("object");
+        expect(typeof item.ordererName).toBe("string");
+        expect(typeof item.ordererEmail).toBe("string");
+        expect(typeof item.quantity).toBe("number");
+      }
+    });
+
+    it("returns 401 when Authorization header is missing", async () => {
+      const res = await fetch(`http://localhost/pocha/dashboard/${POCHA_ID}/`);
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("GET /pocha/dashboard/:pochaID/closed/ (closed orders)", () => {
+    it("returns 200 with { closed } populated from closed fixtures", async () => {
+      const res = await fetch(
+        `http://localhost/pocha/dashboard/${POCHA_ID}/closed/`,
+        { headers: AUTH_HEADER }
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(Array.isArray(body.closed)).toBe(true);
+      expect(body.closed.length).toBeGreaterThan(0);
+      for (const item of body.closed) {
+        expect(item.status).toBe("closed");
+      }
+    });
+  });
+
+  describe("PUT /pocha/dashboard/:orderItemID/change-status/", () => {
+    it("food (isImmediatePrep=false) advances pending → preparing → ready → closed", async () => {
+      // Find a food item in pending status from the active fixture.
+      const orders = await (
+        await fetch(`http://localhost/pocha/dashboard/${POCHA_ID}/`, {
+          headers: AUTH_HEADER,
+        })
+      ).json();
+      const food = orders.pending.find(
+        (o: { menu: { isImmediatePrep: boolean } }) => o.menu.isImmediatePrep === false
+      );
+      expect(food).toBeDefined();
+      const id = food.orderItemID;
+
+      const step = async () => {
+        const res = await fetch(
+          `http://localhost/pocha/dashboard/${id}/change-status/`,
+          { method: "PUT", headers: AUTH_HEADER }
+        );
+        expect(res.status).toBe(200);
+        return (await res.json()).newStatus;
+      };
+
+      expect(await step()).toBe("preparing");
+      expect(await step()).toBe("ready");
+      expect(await step()).toBe("closed");
+    });
+
+    it("drink (isImmediatePrep=true) advances pending → ready → closed (skips preparing)", async () => {
+      const orders = await (
+        await fetch(`http://localhost/pocha/dashboard/${POCHA_ID}/`, {
+          headers: AUTH_HEADER,
+        })
+      ).json();
+      const drink = orders.pending.find(
+        (o: { menu: { isImmediatePrep: boolean } }) => o.menu.isImmediatePrep === true
+      );
+      expect(drink).toBeDefined();
+      const id = drink.orderItemID;
+
+      const r1 = await fetch(
+        `http://localhost/pocha/dashboard/${id}/change-status/`,
+        { method: "PUT", headers: AUTH_HEADER }
+      );
+      expect(r1.status).toBe(200);
+      expect((await r1.json()).newStatus).toBe("ready");
+
+      const r2 = await fetch(
+        `http://localhost/pocha/dashboard/${id}/change-status/`,
+        { method: "PUT", headers: AUTH_HEADER }
+      );
+      expect(r2.status).toBe(200);
+      expect((await r2.json()).newStatus).toBe("closed");
+    });
+
+    it("returns 400 for an item already at closed", async () => {
+      // Closed-orders endpoint gives us a known-closed id.
+      const closed = await (
+        await fetch(`http://localhost/pocha/dashboard/${POCHA_ID}/closed/`, {
+          headers: AUTH_HEADER,
+        })
+      ).json();
+      const id = closed.closed[0].orderItemID;
+      const res = await fetch(
+        `http://localhost/pocha/dashboard/${id}/change-status/`,
+        { method: "PUT", headers: AUTH_HEADER }
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 for an unknown orderItemID", async () => {
+      const res = await fetch(
+        "http://localhost/pocha/dashboard/9999999/change-status/",
+        { method: "PUT", headers: AUTH_HEADER }
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PUT /pocha/dashboard/change-stock/ (menu stock update)", () => {
+    it("updates menusStore for the matched menu and returns { ok, menuID, quantity }", async () => {
+      const res = await fetch("http://localhost/pocha/dashboard/change-stock/", {
+        method: "PUT",
+        headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
+        body: JSON.stringify({ menuID: 101, quantity: 7 }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.menuID).toBe(101);
+      expect(body.quantity).toBe(7);
+
+      // Verify by reading menus through the existing GET endpoint.
+      const menusRes = await fetch(`http://localhost/pocha/menu/${POCHA_ID}/`, {
+        headers: AUTH_HEADER,
+      });
+      const groups = await menusRes.json();
+      const drinks = groups.find(
+        (g: { category: string }) => g.category === "drink"
+      );
+      const soju = drinks.menusList.find(
+        (m: { menuID: number }) => m.menuID === 101
+      );
+      expect(soju.stock).toBe(7);
+    });
+
+    it("returns 400 for negative quantity", async () => {
+      const res = await fetch("http://localhost/pocha/dashboard/change-stock/", {
+        method: "PUT",
+        headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
+        body: JSON.stringify({ menuID: 101, quantity: -3 }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("POST /pocha/_mock/spawn-order/:pochaID/", () => {
+    it("creates a new pending OrderItem from a stocked menu, decrements that menu's stock, returns enriched shape", async () => {
+      // Read menus before spawn.
+      const before = await (
+        await fetch(`http://localhost/pocha/menu/${POCHA_ID}/`, {
+          headers: AUTH_HEADER,
+        })
+      ).json();
+      const stockMap = new Map<number, number>();
+      for (const g of before) for (const m of g.menusList) stockMap.set(m.menuID, m.stock);
+
+      const res = await fetch(
+        `http://localhost/pocha/_mock/spawn-order/${POCHA_ID}/`,
+        { method: "POST", headers: AUTH_HEADER }
+      );
+      expect(res.status).toBe(200);
+      const item = await res.json();
+      expect(typeof item.orderItemID).toBe("number");
+      expect(item.status).toBe("pending");
+      expect(typeof item.menu).toBe("object");
+      expect(typeof item.menu.menuID).toBe("number");
+      expect(typeof item.ordererName).toBe("string");
+      expect(typeof item.ordererEmail).toBe("string");
+      expect(item.quantity).toBeGreaterThanOrEqual(1);
+      expect(item.quantity).toBeLessThanOrEqual(3);
+
+      // Stock for the picked menu decreased.
+      const after = await (
+        await fetch(`http://localhost/pocha/menu/${POCHA_ID}/`, {
+          headers: AUTH_HEADER,
+        })
+      ).json();
+      const newStock = after
+        .flatMap((g: { menusList: { menuID: number; stock: number }[] }) => g.menusList)
+        .find((m: { menuID: number }) => m.menuID === item.menu.menuID).stock;
+      expect(newStock).toBe(stockMap.get(item.menu.menuID)! - item.quantity);
+
+      // The new item shows up in the active orders pending bucket.
+      const orders = await (
+        await fetch(`http://localhost/pocha/dashboard/${POCHA_ID}/`, {
+          headers: AUTH_HEADER,
+        })
+      ).json();
+      expect(
+        orders.pending.some(
+          (o: { orderItemID: number }) => o.orderItemID === item.orderItemID
+        )
+      ).toBe(true);
+    });
+
+    it("returns 409 when every menu item has stock === 0", async () => {
+      // Drain every menu's stock first via change-stock.
+      const groups = await (
+        await fetch(`http://localhost/pocha/menu/${POCHA_ID}/`, {
+          headers: AUTH_HEADER,
+        })
+      ).json();
+      for (const g of groups) {
+        for (const m of g.menusList) {
+          await fetch("http://localhost/pocha/dashboard/change-stock/", {
+            method: "PUT",
+            headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
+            body: JSON.stringify({ menuID: m.menuID, quantity: 0 }),
+          });
+        }
+      }
+      const res = await fetch(
+        `http://localhost/pocha/_mock/spawn-order/${POCHA_ID}/`,
+        { method: "POST", headers: AUTH_HEADER }
+      );
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe("resetOrderStore()", () => {
+    it("re-seeds the order store from fixtures (mutate, reset, read)", async () => {
+      // Mutate: close a pending item.
+      const orders = await (
+        await fetch(`http://localhost/pocha/dashboard/${POCHA_ID}/`, {
+          headers: AUTH_HEADER,
+        })
+      ).json();
+      const id = orders.pending[0].orderItemID;
+      // food: pending → preparing → ready → closed (3 calls)
+      // drink: pending → ready → closed (2 calls)
+      // Brute-force advance until 400.
+      for (let i = 0; i < 4; i++) {
+        const r = await fetch(
+          `http://localhost/pocha/dashboard/${id}/change-status/`,
+          { method: "PUT", headers: AUTH_HEADER }
+        );
+        if (r.status === 400) break;
+      }
+
+      resetOrderStore();
+
+      const after = await (
+        await fetch(`http://localhost/pocha/dashboard/${POCHA_ID}/`, {
+          headers: AUTH_HEADER,
+        })
+      ).json();
+      // The previously-mutated id is back to its original (non-closed) bucket.
+      const all = [...after.pending, ...after.preparing, ...after.ready];
+      expect(all.some((o: { orderItemID: number }) => o.orderItemID === id)).toBe(true);
     });
   });
 });

--- a/src/mocks/handlers/pocha.ts
+++ b/src/mocks/handlers/pocha.ts
@@ -1,11 +1,18 @@
 import { http, HttpResponse } from "msw";
 import {
+  mockOrderItemIDStart,
+  mockOrderItems,
   mockPochaMenus,
   mockPochas,
   type PochaRecord,
 } from "../fixtures/pocha";
 import { convertMenuByCategoryToRawList } from "@/features/pocha/utils/convertMenuType";
-import type { MenuByCategory, MenuItemRaw } from "@/types/pocha";
+import type {
+  MenuByCategory,
+  MenuItem,
+  MenuItemRaw,
+  OrderItem,
+} from "@/types/pocha";
 
 /**
  * Module-level in-memory stores. Mutated by POST/PUT handlers and reset
@@ -19,6 +26,15 @@ import type { MenuByCategory, MenuItemRaw } from "@/types/pocha";
 let pochaStore: PochaRecord[] = [];
 let menusStore: Record<number, MenuItemRaw[]> = {};
 let nextId = 1;
+
+/**
+ * Active pocha for dashboard handlers. Hard-coded to 1 (matches the active
+ * fixture) — dashboard handlers route by pochaID in the URL but the order
+ * store is keyed flat for simplicity.
+ */
+const ACTIVE_DASHBOARD_POCHA_ID = 1;
+let orderItemStore: OrderItem[] = [];
+let nextOrderItemID = mockOrderItemIDStart + mockOrderItems.length;
 
 function seed(): void {
   pochaStore = mockPochas.map((p) => ({
@@ -36,12 +52,43 @@ function seed(): void {
   );
 }
 
+function seedOrders(): void {
+  // Deep-clone so test mutations to embedded `menu` don't bleed into fixtures.
+  orderItemStore = mockOrderItems.map((o) => ({
+    ...o,
+    menu: { ...o.menu },
+  }));
+  nextOrderItemID = mockOrderItemIDStart + mockOrderItems.length;
+}
+
 export function resetPochaStore(): void {
   seed();
 }
 
+export function resetOrderStore(): void {
+  seedOrders();
+}
+
 // Initialize on module load.
 seed();
+seedOrders();
+
+/**
+ * State machine helper — mirrors backend
+ * `KISA-website-server/server/api/pocha/dashboard.py:202-216` exactly.
+ *   food (isImmediatePrep=false): pending → preparing → ready → closed
+ *   drink (isImmediatePrep=true):  pending → ready → closed (skips preparing)
+ * Returns `null` for items already at `closed` (handler maps to 400).
+ */
+type StatusLiteral = "pending" | "preparing" | "ready" | "closed";
+function nextStatus(item: OrderItem): StatusLiteral | null {
+  const s = item.status as unknown as StatusLiteral;
+  if (s === "closed") return null;
+  if (s === "pending") return item.menu.isImmediatePrep ? "ready" : "preparing";
+  if (s === "preparing") return "ready";
+  if (s === "ready") return "closed";
+  return null;
+}
 
 /** Group a raw menu list back into the `MenuByCategory[]` response shape. */
 function groupMenusByCategory(menus: MenuItemRaw[]): MenuByCategory[] {
@@ -151,4 +198,118 @@ export const pochaHandlers = [
       message: "Pocha updated",
     });
   }),
+
+  // --- Dashboard: active orders -------------------------------------------
+  http.get(/\/pocha\/dashboard\/(\d+)\/?$/, ({ request }) => {
+    if (!request.headers.get("Authorization")) {
+      return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const active = orderItemStore.filter((o) => o.status !== "closed");
+    return HttpResponse.json({
+      pending: active.filter((o) => o.status === "pending"),
+      preparing: active.filter((o) => o.status === "preparing"),
+      ready: active.filter((o) => o.status === "ready"),
+    });
+  }),
+
+  // --- Dashboard: closed orders -------------------------------------------
+  http.get(/\/pocha\/dashboard\/(\d+)\/closed\/?$/, ({ request }) => {
+    if (!request.headers.get("Authorization")) {
+      return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return HttpResponse.json({
+      closed: orderItemStore.filter((o) => o.status === "closed"),
+    });
+  }),
+
+  // --- Dashboard: change order status -------------------------------------
+  http.put(/\/pocha\/dashboard\/(\d+)\/change-status\/?$/, ({ request }) => {
+    const url = new URL(request.url);
+    const m = url.pathname.match(/\/pocha\/dashboard\/(\d+)\/change-status\/?$/);
+    const id = m ? Number(m[1]) : NaN;
+    const item = orderItemStore.find((o) => o.orderItemID === id);
+    if (!item) {
+      return HttpResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const next = nextStatus(item);
+    if (next === null) {
+      return HttpResponse.json(
+        { error: "Order item already closed" },
+        { status: 400 }
+      );
+    }
+    item.status = next as unknown as OrderItem["status"];
+    return HttpResponse.json({ newStatus: next });
+  }),
+
+  // --- Dashboard: change menu stock ---------------------------------------
+  http.put(/\/pocha\/dashboard\/change-stock\/?$/, async ({ request }) => {
+    const body = (await request.json()) as { menuID: number; quantity: number };
+    if (typeof body.quantity !== "number" || body.quantity < 0) {
+      return HttpResponse.json(
+        { error: "quantity must be a non-negative number" },
+        { status: 400 }
+      );
+    }
+    for (const list of Object.values(menusStore)) {
+      const target = list.find((m) => m.menuID === body.menuID);
+      if (target) {
+        target.stock = body.quantity;
+        return HttpResponse.json({
+          ok: true,
+          menuID: body.menuID,
+          quantity: body.quantity,
+        });
+      }
+    }
+    return HttpResponse.json({ error: "Menu not found" }, { status: 404 });
+  }),
+
+  // --- Mock-only: spawn a random order ------------------------------------
+  http.post(
+    /\/pocha\/_mock\/spawn-order\/(\d+)\/?$/,
+    ({ request }) => {
+      const url = new URL(request.url);
+      const m = url.pathname.match(/\/pocha\/_mock\/spawn-order\/(\d+)\/?$/);
+      const pochaID = m ? Number(m[1]) : ACTIVE_DASHBOARD_POCHA_ID;
+      const menus = menusStore[pochaID] ?? [];
+      const stocked = menus.filter((mi) => (mi.stock ?? 0) > 0);
+      if (stocked.length === 0) {
+        return HttpResponse.json(
+          { error: "All menu items out of stock" },
+          { status: 409 }
+        );
+      }
+      const picked = stocked[Math.floor(Math.random() * stocked.length)]!;
+      const quantity = Math.min(
+        picked.stock ?? 1,
+        1 + Math.floor(Math.random() * 3)
+      );
+      picked.stock = (picked.stock ?? 0) - quantity;
+
+      const orderers = [
+        { name: "민수", email: "minsoo@umich.edu" },
+        { name: "지영", email: "jiyoung@umich.edu" },
+        { name: "현우", email: "hyunwoo@umich.edu" },
+        { name: "수진", email: "sujin@umich.edu" },
+        { name: "도윤", email: "doyoon@umich.edu" },
+      ];
+      const orderer = orderers[Math.floor(Math.random() * orderers.length)]!;
+      // Ensure the embedded `menu` is a fully-typed MenuItem (menuID required).
+      const menu: MenuItem = {
+        ...picked,
+        menuID: picked.menuID!,
+      };
+      const newItem: OrderItem = {
+        orderItemID: nextOrderItemID++,
+        status: "pending" as unknown as OrderItem["status"],
+        menu,
+        quantity,
+        ordererName: orderer.name,
+        ordererEmail: orderer.email,
+      };
+      orderItemStore.push(newItem);
+      return HttpResponse.json(newItem);
+    }
+  ),
 ];


### PR DESCRIPTION
Closes #116

## Summary
Lane 3.1 — MSW dashboard handlers for `/pocha/dashboard` (mock mode). Adds the 5 endpoints the dashboard needs, plus an order store + 40 fixture orders + 12 TDD tests.

## Changes
- `src/mocks/handlers/pocha.ts` — append:
  - `orderItemStore` + `nextOrderItemID` + `seedOrders()` + `resetOrderStore()` (mirrors pochaStore pattern)
  - `nextStatus(item)` helper — mirrors backend `KISA-website-server/server/api/pocha/dashboard.py:202-216` exactly (food: pending→preparing→ready→closed; drink: pending→ready→closed, skipping preparing)
  - 5 handlers: `GET /pocha/dashboard/:id/`, `GET /pocha/dashboard/:id/closed/`, `PUT /pocha/dashboard/:id/change-status/`, `PUT /pocha/dashboard/change-stock/`, `POST /pocha/_mock/spawn-order/:id/`
- `src/mocks/fixtures/pocha.ts` — append `mockOrderItems` (25 active across pending/preparing/ready + 15 closed) for the active fixture pocha (id=1), with 5 orderer names rotated through.
- `src/mocks/handlers/__tests__/pocha.test.ts` — 12 new tests covering all bullets in the spec; RED-verified before implementation.

## Verification
- `npx tsc --noEmit` — clean
- `npm test` — 82 passed / 3 skipped (12 new + 70 baseline)
- `npm run build` — green

## Scope tag
`[MECHANICAL][TDD]`

## Notes
**URL deviation from spec.** Spec listed paths like `GET /pocha/dashboard/orders/{pochaID}/` and `PUT /pocha/menu/{menuID}/stock/`, but the actual client (`src/apis/pocha/queries.ts:140,187`, `src/apis/pocha/mutations.ts:60,106`) calls `/pocha/dashboard/{id}/`, `/pocha/dashboard/{id}/closed/`, `/pocha/dashboard/{id}/change-status/`, and `/pocha/dashboard/change-stock/` (with body `{menuID, quantity}`). Handlers match the actual client paths so the dashboard works in mock mode without changing app code (per the lane's "no app code under src/app, src/features, src/components touched" rule).

**`isolatedModules` quirk.** `OrderStatus` is a `const enum`; under `isolatedModules: true` its values can't be imported cross-module. Used string literals with a single `as unknown as OrderItem["status"]` cast in the fixture builder + handler hot paths to avoid touching `src/types/pocha.ts`. Long-term cleanup candidate: convert `OrderStatus` to a string-literal union.

## Non-goals (deferred)
- WS disable / Simulate button wiring → lane 3.3
- Stats utils → lane 3.2
- Any backend changes
