### PR TITLE
[Phase 3 / 3.6] POLISH: Food/Drink grids — DS Badge headers + drop STATUS_COLORS

### DIFF
--- a/src/features/pocha/components/dashboard/DrinkOrderGrid.tsx
+++ b/src/features/pocha/components/dashboard/DrinkOrderGrid.tsx
@@ -1,7 +1,7 @@
 import { OrderStatus, Orders } from "@/types/pocha";
 import React from "react";
 import OrderItemCard from "@/features/pocha/components/dashboard/OrderItemCard";
-import { STATUS_COLORS } from "@/features/pocha/utils/statusToColor";
+import { Badge } from "@umichkisa-ds/web";
 
 interface DrinkOrderGridProps {
   orders: Orders;
@@ -11,56 +11,63 @@ interface DrinkOrderGridProps {
   ) => void;
 }
 
+type ColumnStatus = "pending" | "ready";
+
+const STATUS_LABEL: Record<ColumnStatus, string> = {
+  pending: "Pending",
+  ready: "Ready",
+};
+
+const STATUS_BADGE_VARIANT: Record<ColumnStatus, "warning" | "success"> = {
+  pending: "warning",
+  ready: "success",
+};
+
 export default function DrinkOrderGrid({
   orders = { pending: [], preparing: [], ready: [] },
   updateOrderItemStatusUI,
 }: DrinkOrderGridProps) {
-  const { pending, preparing, ready } = orders;
+  const { pending, ready } = orders;
 
-  const itemStatusHeaderStyle = (status: string) => {
-    const style = `text-lg font-semibold
-     flex items-center justify-center p-1 rounded-md`;
-
-    if (status === "pending") return `${style} ${STATUS_COLORS.pending} `;
-    if (status === "preparing") return `${style} ${STATUS_COLORS.preparing} `;
-    if (status === "ready") return `${style} ${STATUS_COLORS.ready}`;
-  };
+  const columns: { status: ColumnStatus; items: typeof pending }[] = [
+    { status: "pending", items: pending ?? [] },
+    { status: "ready", items: ready ?? [] },
+  ];
 
   return (
-    <div className="flex flex-col self-stretch gap-2 bg-slate-100 p-2 rounded-lg">
-      <h2 className="text-2xl font-bold">Drink Orders</h2>
+    <div className="flex flex-col self-stretch gap-2 bg-surface-subtle p-2 rounded-md">
+      <h2 className="type-h2 ml-2">Drink Orders</h2>
       <div className="flex gap-2">
-        <div className="flex-1">
-          <div className={itemStatusHeaderStyle("pending")}>
-            <h3>Pending</h3>
+        {columns.map(({ status, items }) => (
+          <div
+            key={status}
+            className="flex-1 flex flex-col gap-2 p-2 rounded-md border border-border bg-surface-subtle"
+          >
+            <div className="flex items-center justify-center gap-2">
+              <Badge variant={STATUS_BADGE_VARIANT[status]}>
+                {STATUS_LABEL[status]}
+              </Badge>
+              <span className="type-caption text-muted-foreground">
+                {items.length}
+              </span>
+            </div>
+            {items.length === 0 ? (
+              <p className="type-caption text-muted-foreground text-center">
+                None
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {items.map((order) => (
+                  <OrderItemCard
+                    key={order.orderItemID}
+                    order={order}
+                    updateOrderItemStatusUI={updateOrderItemStatusUI}
+                  />
+                ))}
+              </ul>
+            )}
           </div>
-          <ul className="flex flex-col gap-2 mt-2">
-            {pending?.map((order) => (
-              <OrderItemCard
-                isDrink={true}
-                key={order.orderItemID}
-                order={order}
-                updateOrderItemStatusUI={updateOrderItemStatusUI}
-              />
-            ))}
-          </ul>
-        </div>
-
-        <div className="flex-1">
-          <div className={itemStatusHeaderStyle("ready")}>
-            <h3>Ready</h3>
-          </div>
-          <ul className="flex flex-col gap-2 mt-2">
-            {ready?.map((order) => (
-              <OrderItemCard
-                isDrink={true}
-                key={order.orderItemID}
-                order={order}
-                updateOrderItemStatusUI={updateOrderItemStatusUI}
-              />
-            ))}
-          </ul>
-        </div>
+        ))}
       </div>
     </div>
   );

--- a/src/features/pocha/components/dashboard/FoodOrderGrid.tsx
+++ b/src/features/pocha/components/dashboard/FoodOrderGrid.tsx
@@ -1,7 +1,7 @@
 import { OrderStatus, Orders } from "@/types/pocha";
 import React from "react";
 import OrderItemCard from "@/features/pocha/components/dashboard/OrderItemCard";
-import { STATUS_COLORS } from "@/features/pocha/utils/statusToColor";
+import { Badge } from "@umichkisa-ds/web";
 
 interface FoodOrderGridProps {
   orders: Orders;
@@ -11,69 +11,69 @@ interface FoodOrderGridProps {
   ) => void;
 }
 
+type ColumnStatus = "pending" | "preparing" | "ready";
+
+const STATUS_LABEL: Record<ColumnStatus, string> = {
+  pending: "Pending",
+  preparing: "Preparing",
+  ready: "Ready",
+};
+
+const STATUS_BADGE_VARIANT: Record<
+  ColumnStatus,
+  "warning" | "info" | "success"
+> = {
+  pending: "warning",
+  preparing: "info",
+  ready: "success",
+};
+
 export default function FoodOrderGrid({
   orders = { pending: [], preparing: [], ready: [] },
   updateOrderItemStatusUI,
 }: FoodOrderGridProps) {
   const { pending, preparing, ready } = orders;
 
-  const itemStatusHeaderStyle = (status: string) => {
-    const style = `text-lg font-semibold
-     flex items-center justify-center p-1 rounded-md`;
-
-    if (status === "pending") return `${style} ${STATUS_COLORS.pending} `;
-    if (status === "preparing") return `${style} ${STATUS_COLORS.preparing} `;
-    if (status === "ready") return `${style} ${STATUS_COLORS.ready}`;
-  };
+  const columns: { status: ColumnStatus; items: typeof pending }[] = [
+    { status: "pending", items: pending ?? [] },
+    { status: "preparing", items: preparing ?? [] },
+    { status: "ready", items: ready ?? [] },
+  ];
 
   return (
-    <div className="flex flex-col self-stretch gap-2 bg-slate-100 p-2 rounded-lg">
-      <h2 className="text-2xl font-bold ml-2">Food Orders</h2>
+    <div className="flex flex-col self-stretch gap-2 bg-surface-subtle p-2 rounded-md">
+      <h2 className="type-h2 ml-2">Food Orders</h2>
       <div className="flex gap-2">
-        <div className="flex-1">
-          <div className={itemStatusHeaderStyle("pending")}>
-            <h3>Pending</h3>
+        {columns.map(({ status, items }) => (
+          <div
+            key={status}
+            className="flex-1 flex flex-col gap-2 p-2 rounded-md border border-border bg-surface-subtle"
+          >
+            <div className="flex items-center justify-center gap-2">
+              <Badge variant={STATUS_BADGE_VARIANT[status]}>
+                {STATUS_LABEL[status]}
+              </Badge>
+              <span className="type-caption text-muted-foreground">
+                {items.length}
+              </span>
+            </div>
+            {items.length === 0 ? (
+              <p className="type-caption text-muted-foreground text-center">
+                None
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {items.map((order) => (
+                  <OrderItemCard
+                    key={order.orderItemID}
+                    order={order}
+                    updateOrderItemStatusUI={updateOrderItemStatusUI}
+                  />
+                ))}
+              </ul>
+            )}
           </div>
-          <ul className="flex flex-col gap-2 mt-2">
-            {pending?.map((order) => (
-              <OrderItemCard
-                key={order.orderItemID}
-                order={order}
-                updateOrderItemStatusUI={updateOrderItemStatusUI}
-              />
-            ))}
-          </ul>
-        </div>
-
-        <div className="flex-1">
-          <div className={itemStatusHeaderStyle("preparing")}>
-            <h3>Preparing</h3>
-          </div>
-          <ul className="flex flex-col gap-2 mt-2">
-            {preparing?.map((order) => (
-              <OrderItemCard
-                key={order.orderItemID}
-                order={order}
-                updateOrderItemStatusUI={updateOrderItemStatusUI}
-              />
-            ))}
-          </ul>
-        </div>
-
-        <div className="flex-1">
-          <div className={itemStatusHeaderStyle("ready")}>
-            <h3>Ready</h3>
-          </div>
-          <ul className="flex flex-col gap-2 mt-2">
-            {ready?.map((order) => (
-              <OrderItemCard
-                key={order.orderItemID}
-                order={order}
-                updateOrderItemStatusUI={updateOrderItemStatusUI}
-              />
-            ))}
-          </ul>
-        </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #121

## 🤔 Needs decision

**Stuck on:** Lane 3.6 acceptance criterion "delete `src/features/pocha/utils/statusToColor.ts`" is unsatisfiable within the issue's `## Files` scope.

**What I attempted:** Implemented the in-scope redesign (column shells, Badge headers, drop `STATUS_COLORS` import + `isDrink` prop, fix DrinkOrderGrid to 2 columns). Verified `statusToColor.ts` callers across the repo before attempting the delete.

**What's unclear:** `src/features/pocha/components/order/PochaOrderItem.tsx` (outside the lane's `## Files` — different feature folder, not in the dashboard subtree) still imports both `STATUS_COLORS` and `STATUS_TEXT_COLORS`:

```
src/features/pocha/components/order/PochaOrderItem.tsx:8:  STATUS_TEXT_COLORS,
src/features/pocha/components/order/PochaOrderItem.tsx:9:  STATUS_COLORS,
```

Deleting `statusToColor.ts` would break that consumer — that's out-of-scope file drift. The lane spec assumes only the dashboard files use it, which doesn't hold against the actual codebase.

**Options:**
1. **Defer the delete to a future lane** that also migrates `PochaOrderItem.tsx` (e.g., a Phase 3 / Phase 4 follow-up that owns the `pocha/components/order/` subtree). Merge this PR as-is. Tradeoff: `statusToColor.ts` survives until that lane lands; one extra carry-over.
2. **Expand this PR's scope** to migrate `PochaOrderItem.tsx` too (DS-tokenize its status indicator, drop `STATUS_TEXT_COLORS` usage). Tradeoff: lane scope creep into a different feature folder; needs visual review since PochaOrderItem is a user-facing order tile, not a dashboard column header.
3. **Bail entirely** and re-spec lane 3.6 to either include `PochaOrderItem.tsx` upfront or drop the deletion AC. Tradeoff: cycle this PR.

**My weak preference:** Option 1 — defer the delete. The redesign work this lane was supposed to ship is fully done; the dead-import cleanup is tracked separately. If a Phase 4 (pocha-userfacing) lane will rewrite the order tile anyway, we'd touch `PochaOrderItem.tsx` there and can drop `statusToColor.ts` then.

## Summary

In-scope rewrite of `FoodOrderGrid.tsx` and `DrinkOrderGrid.tsx` per locked spec. DS-tokenized column shells, DS `Badge` column headers (status-toned variants), `"None"` empty-state caption per column, drop legacy `STATUS_COLORS` map and `itemStatusHeaderStyle` helper. DrinkOrderGrid trimmed from 3 columns to 2 (drops the unreachable `preparing` column per the state machine). DrinkOrderGrid stops passing `isDrink={true}` to `OrderItemCard` (lane 3.5's deprecated optional prop is no longer fed by anyone after this lane).

## Changes

- `src/features/pocha/components/dashboard/FoodOrderGrid.tsx`
  - Drops `STATUS_COLORS` import + `itemStatusHeaderStyle` helper
  - Adds `STATUS_LABEL` (`Pending`/`Preparing`/`Ready`) and `STATUS_BADGE_VARIANT` (`warning`/`info`/`success`) maps
  - Column shell: `border border-border bg-surface-subtle rounded-md` (DS tokens)
  - Header: `<Badge variant={...}>{label}</Badge>` + count caption
  - Empty state: centered muted `"None"` caption
- `src/features/pocha/components/dashboard/DrinkOrderGrid.tsx`
  - Same column-shell/header/empty rewrite
  - Trimmed to 2 columns: `pending`, `ready` (drops `preparing`)
  - Stops passing `isDrink={true}` to `<OrderItemCard>`

## Verification

- `npx tsc --noEmit` — no new errors (pre-existing `tsconfig.json` `TS5107` deprecation only).
- No `// pastiche-unresolved-doubt:` markers in the diff.
- Pastiche reviewer: zero doubts (atoms + tokens + variants all FACT/KNOWLEDGE-listed; no WISDOM violations).

## Scope tag

`[POLISH][NO-TDD]`

## Notes

- `statusToColor.ts` deletion deferred — see `## Needs decision` block above.
- This PR depends on PR #132 (lane 3.5) only for the `isDrink` prop becoming optional/deprecated; both PRs can land in either order without compile breaks since lane 3.5 keeps the prop accepted.

Resolve the `## Needs decision` block by leaving a comment with the chosen option. Remove `needs-decision`, add `needs-revision` — the next routine revises (or, for Option 1, simply remove draft + flip to `ready-for-review`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc6Tj3iGZrfSC8FcnhbYPF)_