### PR TITLE
[Phase 3 / 3.8] REDESIGN: Stock tab — DS Table + inline-edit + filter chips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@stripe/stripe-js": "4.10.0",
         "@tailwindcss/postcss": "4.2.2",
         "@umichkisa-ds/form": "1.0.1",
-        "@umichkisa-ds/web": "1.0.22",
+        "@umichkisa-ds/web": "1.0.24",
         "@vercel/analytics": "1.3.1",
         "@vercel/speed-insights": "^1.3.1",
         "aws-sdk": "^2.1496.0",
@@ -12999,9 +12999,9 @@
       }
     },
     "node_modules/@umichkisa-ds/web": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@umichkisa-ds/web/-/web-1.0.22.tgz",
-      "integrity": "sha512-12osE3fCmrL29AcnUZPN0XZBxE4+Dg9/WSHyyhJUfuWtrZJPoxJ/3c0Y0VgDX4n8gBAU2x2buPR7j1zEdaLgvA==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@umichkisa-ds/web/-/web-1.0.24.tgz",
+      "integrity": "sha512-R0HZuZPuKvIfze6eRpLS8xQHf+cVt/sMDZ2dGLkwSha72X1rB4oR1uFSdQIe65HzviBlMlv03Gs/EZdOCi1mpQ==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@stripe/stripe-js": "4.10.0",
     "@tailwindcss/postcss": "4.2.2",
     "@umichkisa-ds/form": "1.0.1",
-    "@umichkisa-ds/web": "1.0.22",
+    "@umichkisa-ds/web": "1.0.24",
     "@vercel/analytics": "1.3.1",
     "@vercel/speed-insights": "^1.3.1",
     "aws-sdk": "^2.1496.0",

--- a/src/features/pocha/components/dashboard/StockManager.tsx
+++ b/src/features/pocha/components/dashboard/StockManager.tsx
@@ -299,14 +299,13 @@ export default function StockManager({ pochaID, token }: StockManagerProps) {
         onValueChange={(v) => setFilter(v as StockFilter)}
         aria-label="Filter stock"
       />
-      {/* pastiche-unresolved-doubt: lane spec calls for a refresh IconButton in the toolbar, but the DS Icon registry has no refresh-cw / rotate-cw / refresh / arrow-circle entry; falling back to a tertiary text Button so we don't ship an IconButton with a wrong-meaning icon. */}
-      <Button
+      <IconButton
+        icon="refresh-cw"
+        aria-label="Refresh stock"
+        size="sm"
         variant="tertiary"
         onClick={() => refetch()}
-        aria-label="Refresh stock"
-      >
-        Refresh
-      </Button>
+      />
     </div>
   );
 

--- a/src/features/pocha/components/dashboard/StockManager.tsx
+++ b/src/features/pocha/components/dashboard/StockManager.tsx
@@ -1,114 +1,467 @@
-import React, { useState } from "react";
+"use client";
+
+import {
+  type FocusEvent,
+  type KeyboardEvent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+  Icon,
+  IconButton,
+  Input,
+  Skeleton,
+  StatusView,
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableMobileItem,
+  TableMobileList,
+  TableRow,
+  ToggleGroup,
+  toast,
+} from "@umichkisa-ds/web";
 import useMenu from "../../hooks/useMenu";
-import LoadingSpinner from "@/components/ui/feedback/LoadingSpinner";
-import { changeStock } from "@/apis/pocha/mutations";
+import type { MenuItem } from "@/types/pocha";
 
 interface StockManagerProps {
   pochaID: number;
   token: string;
 }
 
+type StockFilter = "all" | "in" | "low" | "sold-out";
+
+type FlatRow = MenuItem & { category: string };
+
+const ERROR_TOAST = "Failed to update stock";
+const SOLD_OUT_TOAST = "Marked sold out";
+
+function isLow(stock: number) {
+  return stock >= 1 && stock <= 3;
+}
+
+function matchFilter(filter: StockFilter, stock: number) {
+  switch (filter) {
+    case "in":
+      return stock > 0;
+    case "low":
+      return isLow(stock);
+    case "sold-out":
+      return stock === 0;
+    case "all":
+    default:
+      return true;
+  }
+}
+
 export default function StockManager({ pochaID, token }: StockManagerProps) {
-  const { menuList, status } = useMenu(pochaID, token);
-  const [selectedMenu, setSelectedMenu] = useState<number | null>(null);
-  const [customStock, setCustomStock] = useState<string>("");
+  const { menuList, status, error, refetch, updateMenuStock } = useMenu(
+    pochaID,
+    token
+  );
 
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [filter, setFilter] = useState<StockFilter>("all");
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [draftValue, setDraftValue] = useState<string>("");
+  const [confirmId, setConfirmId] = useState<number | null>(null);
 
-  const handleReload = () => {
-    window.location.reload();
-  };
+  // Per-row request id for last-write-wins race safety. NOT in useMenu.
+  const latestReqId = useRef<Map<number, number>>(new Map());
 
-  const handleSelectMenu = (menuID: number) => {
-    setSelectedMenu(menuID);
-  };
-
-  const handleSetStock = async (quantity: number) => {
-    if (selectedMenu === null) return;
-
-    if (quantity < 0 || customStock === "") {
-      alert("Please type a valid number");
-      setCustomStock("");
-      return;
+  const flatRows: FlatRow[] = useMemo(() => {
+    if (!menuList) return [];
+    const rows: FlatRow[] = [];
+    for (const cat of menuList) {
+      for (const menu of cat.menusList) {
+        rows.push({ ...menu, category: cat.category });
+      }
     }
+    return rows;
+  }, [menuList]);
 
-    if (isNaN(quantity)) {
-      alert("Please type a valid number");
-      setCustomStock("");
-      return;
+  const counts = useMemo(() => {
+    let all = 0;
+    let inStock = 0;
+    let low = 0;
+    let soldOut = 0;
+    for (const row of flatRows) {
+      all += 1;
+      if (row.stock > 0) inStock += 1;
+      if (isLow(row.stock)) low += 1;
+      if (row.stock === 0) soldOut += 1;
     }
+    return { all, inStock, low, soldOut };
+  }, [flatRows]);
 
-    setIsLoading(true);
-    const res = await changeStock({ menuID: selectedMenu, quantity });
-    if (res) {
-      alert(`Stock updated to ${quantity} successfully`);
-      window.location.reload();
+  const visibleRows = useMemo(
+    () => flatRows.filter((row) => matchFilter(filter, row.stock)),
+    [flatRows, filter]
+  );
+
+  const filterItems = useMemo(
+    () => [
+      { value: "all", label: `All (${counts.all})` },
+      { value: "in", label: `In stock (${counts.inStock})` },
+      { value: "low", label: `Low (${counts.low})` },
+      { value: "sold-out", label: `Sold out (${counts.soldOut})` },
+    ],
+    [counts]
+  );
+
+  const beginEdit = useCallback((row: FlatRow) => {
+    setEditingId(row.menuID);
+    setDraftValue(String(row.stock));
+  }, []);
+
+  const cancelEdit = useCallback(() => {
+    setEditingId(null);
+    setDraftValue("");
+  }, []);
+
+  const commitEdit = useCallback(
+    async (row: FlatRow) => {
+      const trimmed = draftValue.trim();
+      // No-op: empty string OR unchanged value → silent exit.
+      if (trimmed === "" || Number(trimmed) === row.stock) {
+        cancelEdit();
+        return;
+      }
+      const parsed = Number(trimmed);
+      if (Number.isNaN(parsed) || parsed < 0) {
+        cancelEdit();
+        return;
+      }
+
+      // Bump per-row request id and capture mine.
+      const prev = latestReqId.current.get(row.menuID) ?? 0;
+      const myId = prev + 1;
+      latestReqId.current.set(row.menuID, myId);
+
+      cancelEdit();
+
+      const ok = await updateMenuStock(row.menuID, parsed);
+
+      // Stale write — drop silently.
+      if (myId !== latestReqId.current.get(row.menuID)) return;
+
+      if (!ok) {
+        toast.error(ERROR_TOAST);
+      }
+      // Inline-edit success is silent; the cell's new value is the confirmation.
+    },
+    [draftValue, cancelEdit, updateMenuStock]
+  );
+
+  const advanceFocus = useCallback(
+    (currentMenuID: number, direction: 1 | -1) => {
+      const idx = visibleRows.findIndex((r) => r.menuID === currentMenuID);
+      if (idx < 0) return false;
+      const nextIdx = idx + direction;
+      if (nextIdx < 0 || nextIdx >= visibleRows.length) return false;
+      const nextRow = visibleRows[nextIdx];
+      // Enter edit mode on the next row; the freshly-mounted input
+      // carries `autoFocus`, which moves focus + selection there.
+      setEditingId(nextRow.menuID);
+      setDraftValue(String(nextRow.stock));
+      return true;
+    },
+    [visibleRows]
+  );
+
+  const handleKeyDown = useCallback(
+    async (e: KeyboardEvent<HTMLInputElement>, row: FlatRow) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        cancelEdit();
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        await commitEdit(row);
+        return;
+      }
+      if (e.key === "Tab") {
+        e.preventDefault();
+        await commitEdit(row);
+        const direction: 1 | -1 = e.shiftKey ? -1 : 1;
+        const advanced = advanceFocus(row.menuID, direction);
+        if (!advanced) {
+          // At list boundary → plain blur.
+          (e.target as HTMLInputElement).blur();
+        }
+      }
+    },
+    [advanceFocus, cancelEdit, commitEdit]
+  );
+
+  const handleBlur = useCallback(
+    async (e: FocusEvent<HTMLInputElement>, row: FlatRow) => {
+      // Only commit if we're still editing this row (Tab/Enter handlers
+      // may have already advanced or cancelled).
+      if (editingId !== row.menuID) return;
+      // Avoid stealing commit when blur is fired by our own programmatic
+      // focus advance (the relatedTarget will be another row's input).
+      const next = e.relatedTarget as HTMLElement | null;
+      if (
+        next &&
+        next.tagName === "INPUT" &&
+        next.getAttribute("data-stock-input") === "true"
+      ) {
+        return;
+      }
+      await commitEdit(row);
+    },
+    [commitEdit, editingId]
+  );
+
+  const handleConfirmZero = useCallback(async () => {
+    if (confirmId === null) return;
+    const menuID = confirmId;
+    setConfirmId(null);
+
+    const prev = latestReqId.current.get(menuID) ?? 0;
+    const myId = prev + 1;
+    latestReqId.current.set(menuID, myId);
+
+    const ok = await updateMenuStock(menuID, 0);
+    if (myId !== latestReqId.current.get(menuID)) return;
+
+    if (ok) {
+      toast.success(SOLD_OUT_TOAST);
     } else {
-      alert("Failed to update stock");
+      toast.error(ERROR_TOAST);
     }
-    setIsLoading(false);
-  };
+  }, [confirmId, updateMenuStock]);
 
-  const handleSetStockToZero = () => {
-    handleSetStock(0);
-  };
-
+  // ── Loading ────────────────────────────────────────────
   if (status === "loading") {
-    return <LoadingSpinner fullScreen={false} label="메뉴를 가져오는중..." />;
+    return (
+      <div className="w-full">
+        <div className="mb-4 flex items-center justify-between gap-4">
+          <Skeleton className="h-9 w-72" />
+          <Skeleton className="h-10 w-10" />
+        </div>
+        <div className="hidden md:block">
+          <div className="flex flex-col gap-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-12" />
+            ))}
+          </div>
+        </div>
+        <div className="block md:hidden">
+          <div className="flex flex-col gap-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-16" />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
   }
 
+  // ── Error ──────────────────────────────────────────────
+  if (status === "error") {
+    return (
+      <StatusView
+        variant="error"
+        title="Couldn't load stock"
+        description={error?.message ?? "Something went wrong."}
+        action={
+          <Button variant="secondary" onClick={() => refetch()}>
+            Try again
+          </Button>
+        }
+      />
+    );
+  }
+
+  // ── Toolbar (filter chips + refresh) ───────────────────
+  const toolbar = (
+    <div className="mb-4 flex items-center justify-between gap-4">
+      <ToggleGroup
+        type="single"
+        items={filterItems}
+        value={filter}
+        onValueChange={(v) => setFilter(v as StockFilter)}
+        aria-label="Filter stock"
+      />
+      {/* pastiche-unresolved-doubt: lane spec calls for a refresh IconButton in the toolbar, but the DS Icon registry has no refresh-cw / rotate-cw / refresh / arrow-circle entry; falling back to a tertiary text Button so we don't ship an IconButton with a wrong-meaning icon. */}
+      <Button
+        variant="tertiary"
+        onClick={() => refetch()}
+        aria-label="Refresh stock"
+      >
+        Refresh
+      </Button>
+    </div>
+  );
+
+  // ── Render row helpers ─────────────────────────────────
+  const renderStockCell = (row: FlatRow) => {
+    if (editingId === row.menuID) {
+      return (
+        <Input
+          autoFocus
+          type="number"
+          min={0}
+          inputMode="numeric"
+          data-stock-input="true"
+          value={draftValue}
+          onChange={(e) => setDraftValue(e.target.value)}
+          onFocus={(e) => e.currentTarget.select()}
+          onKeyDown={(e) => handleKeyDown(e, row)}
+          onBlur={(e) => handleBlur(e, row)}
+          aria-label={`Stock for ${row.nameEng || row.nameKor}`}
+          className="w-24"
+        />
+      );
+    }
+    return (
+      <button
+        type="button"
+        onClick={() => beginEdit(row)}
+        aria-label={`Edit stock for ${row.nameEng || row.nameKor}`}
+        className="rounded-md px-2 py-1 text-left type-body text-foreground hover:bg-brand-accent-subtle focus-visible:outline-2 focus-visible:outline-focus-ring focus-visible:outline-offset-2"
+      >
+        {row.stock}
+      </button>
+    );
+  };
+
+  // ── Empty / table / mobile ────────────────────────────
   return (
     <div className="w-full">
-      <button
-        onClick={handleReload}
-        className="px-4 py-2 bg-blue-500 text-white"
-      >
-        Reload Stock
-      </button>
-      <ul className="mt-4 space-y-2">
-        {menuList?.map(({ menusList }) =>
-          menusList.map((menu) => (
-            <li
-              key={menu.menuID}
-              className={`p-2 border ${
-                selectedMenu === menu.menuID ? "bg-gray-300" : ""
-              }`}
-              onClick={() => handleSelectMenu(menu.menuID)}
-            >
-              {menu.nameKor} - Stock: {menu.stock}
-            </li>
-          ))
-        )}
-      </ul>
-      <div className="flex flex-row gap-4 mt-4">
-        <button
-          onClick={handleSetStockToZero}
-          disabled={selectedMenu === null || isLoading}
-          className={`px-4 py-2 rounded-lg ${
-            selectedMenu !== null ? "bg-red-500 text-white" : "bg-gray-300"
-          }`}
-        >
-          {isLoading ? "Loading..." : "Set Stock to 0"}
-        </button>
+      {toolbar}
 
-        <button
-          onClick={() => handleSetStock(Number(customStock))}
-          disabled={selectedMenu === null || isLoading}
-          className={`px-4 py-2 rounded-lg ${
-            selectedMenu !== null ? "bg-green-500 text-white" : "bg-gray-300"
-          }`}
-        >
-          {isLoading ? "Loading..." : "Set Stock to Custom Value"}
-        </button>
-        <input
-          type="number"
-          min="0"
-          pattern="[0-9]+"
-          value={customStock}
-          onChange={(e) => setCustomStock(e.target.value)}
-          className="px-4 py-2 border"
-        />
+      {/* Desktop / tablet table */}
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Menu</TableHead>
+              <TableHead>Category</TableHead>
+              <TableHead>Stock</TableHead>
+              <TableHead className="w-px">
+                <span className="sr-only">Actions</span>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {visibleRows.map((row) => (
+              <TableRow key={row.menuID}>
+                <TableCell>
+                  <span className="type-body text-foreground">
+                    {row.nameEng || row.nameKor}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <span className="type-body-sm text-muted-foreground">
+                    {row.category}
+                  </span>
+                </TableCell>
+                <TableCell>{renderStockCell(row)}</TableCell>
+                <TableCell className="text-right">
+                  <IconButton
+                    icon="circle-minus"
+                    aria-label="Mark sold out"
+                    size="sm"
+                    variant="tertiary"
+                    disabled={row.stock === 0}
+                    onClick={() => setConfirmId(row.menuID)}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+          {visibleRows.length === 0 && (
+            <TableCaption>No items match this filter</TableCaption>
+          )}
+        </Table>
       </div>
+
+      {/* Mobile list-card */}
+      <div className="block md:hidden">
+        {visibleRows.length === 0 ? (
+          <Card>
+            <CardContent className="py-6">
+              <CardDescription className="text-center">
+                No items match this filter
+              </CardDescription>
+            </CardContent>
+          </Card>
+        ) : (
+          <TableMobileList>
+            {visibleRows.map((row) => (
+              <TableMobileItem key={row.menuID}>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex flex-col gap-1 min-w-0">
+                    <span className="type-label text-foreground truncate">
+                      {row.nameEng || row.nameKor}
+                    </span>
+                    <span className="type-caption text-muted-foreground">
+                      {row.category}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <div className="flex flex-col items-end gap-0.5">
+                      <span className="type-caption text-muted-foreground">
+                        Stock
+                      </span>
+                      {renderStockCell(row)}
+                    </div>
+                    <IconButton
+                      icon="circle-minus"
+                      aria-label="Mark sold out"
+                      size="sm"
+                      variant="tertiary"
+                      disabled={row.stock === 0}
+                      onClick={() => setConfirmId(row.menuID)}
+                    />
+                  </div>
+                </div>
+              </TableMobileItem>
+            ))}
+          </TableMobileList>
+        )}
+      </div>
+
+      {/* Confirm-zero dialog */}
+      <Dialog
+        open={confirmId !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmId(null);
+        }}
+      >
+        <DialogContent size="sm">
+          <DialogTitle>Set stock to 0?</DialogTitle>
+          <DialogDescription>
+            This item won&apos;t be orderable.
+          </DialogDescription>
+          <DialogFooter>
+            <Button variant="secondary" onClick={() => setConfirmId(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmZero}>
+              <Icon name="circle-minus" size="sm" />
+              Set to 0
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/features/pocha/hooks/useMenu.tsx
+++ b/src/features/pocha/hooks/useMenu.tsx
@@ -5,14 +5,16 @@
 
 import useSWR from "swr";
 import { fetcherWithToken } from "@/lib/swr/fetchers";
+import { changeStock } from "@/apis/pocha/mutations";
 import { MenuByCategory } from "@/types/pocha";
 
 /**
  * @desc hook to fetch menu of pocha with SWR and existing fetcher
  *
- * Returns `{ menuList, status, error, refetch }` to match the surface of
- * `usePocha`. `refetch` is a thin wrapper over SWR's `mutate` for the
- * current key; callers can invoke it without knowing SWR cache keys.
+ * Returns `{ menuList, status, error, refetch, updateMenuStock }`. `refetch`
+ * is a thin wrapper over SWR's `mutate`. `updateMenuStock` performs an
+ * optimistic write of a single row's stock without triggering a
+ * round-trip refetch on success; on failure it reconciles via `refetch()`.
  */
 const useMenu = (pochaID: number, token: string) => {
   const {
@@ -20,7 +22,7 @@ const useMenu = (pochaID: number, token: string) => {
     error,
     isLoading,
     mutate,
-  } = useSWR(
+  } = useSWR<MenuByCategory[]>(
     pochaID && token ? [`/pocha/menu/${pochaID}/`, token] : null,
     fetcherWithToken,
     {
@@ -30,11 +32,49 @@ const useMenu = (pochaID: number, token: string) => {
     }
   );
 
+  /**
+   * Optimistically patch the row's `stock` in the nested
+   * `MenuByCategory[]` cache, then issue the mutation. Returns
+   * `true` on success, `false` on failure (and reconciles via
+   * `refetch()` so the cache returns to server truth).
+   */
+  const updateMenuStock = async (
+    menuID: number,
+    quantity: number
+  ): Promise<boolean> => {
+    const patch = (current: MenuByCategory[] | undefined) => {
+      if (!current) return current;
+      return current.map((category) => ({
+        ...category,
+        menusList: category.menusList.map((menu) =>
+          menu.menuID === menuID ? { ...menu, stock: quantity } : menu
+        ),
+      }));
+    };
+
+    // Optimistic write — do not revalidate on every keystroke commit.
+    await mutate(patch, { revalidate: false });
+
+    try {
+      const res = await changeStock({ menuID, quantity });
+      if (!res) {
+        // Reconcile to server truth on silent failure.
+        await mutate();
+        return false;
+      }
+      return true;
+    } catch {
+      await mutate();
+      return false;
+    }
+  };
+
   return {
     menuList: menuList as MenuByCategory[],
     status: error ? "error" : isLoading ? "loading" : "success",
     error: error as Error | undefined,
     refetch: () => mutate(),
+    updateMenuStock,
   };
 };
 


### PR DESCRIPTION
Closes #122

## 🤔 Needs decision

**Stuck on:** DS `Icon` registry has no refresh-class icon for the toolbar refresh affordance.

**What I attempted:** The lane spec (issue #122 A10 + Toolbar section) calls for a refresh icon-button on the toolbar that calls `refetch()`. Pastiche searched the DS `Icon` registry for `refresh-cw` / `rotate-cw` / `refresh` / `arrow-circle*` entries and found none.

**What's unclear:** which path to take so we don't ship an `IconButton` with a wrong-meaning icon. Pastiche fell back to a tertiary text `Button` labeled `Refresh` and dropped a `// pastiche-unresolved-doubt:` marker at `StockManager.tsx:302` (per the protocol's bailout-via-marker convention).

**Options:**
1. **Accept the text-button fallback.** Merge as-is; remove the marker line in a follow-up commit. Tradeoff: minor UX inconsistency vs. the `History` tab and other DS-iconned toolbars to come; cheap to revisit later.
2. **Add a refresh icon to the DS registry** (`refresh-cw` from lucide). One-line registry addition + DS patch bump. Tradeoff: a `ds-fix-during-migration` cycle here, but the icon will be reused across `StockManager`, `History`, and any future dashboard refresh affordance.
3. **Use a different existing DS icon.** No good lucide-named alternative — `redo` / `arrow-clockwise` aren't in the registry either.

**My weak preference:** Option 2 — add `refresh-cw` to the DS Icon registry as a small mid-phase patch. The cost is a routine `ds-fix-during-migration` cycle; the payoff is a properly iconned toolbar matching the rest of the dashboard. **However, autonomous Claude is not permitted to invoke `ds-fix-during-migration` (per AP §8).** Surfacing here for human decision.

## Summary

Full DS-native rewrite of the Stock tab. `StockManager.tsx` now renders a DS `Table` (tablet/desktop) paired with `TableMobileList` / `TableMobileItem` (mobile) over flattened `{...menu, category}` rows. Stock cells are single-tap inline-edit with `Tab`/`Shift+Tab` focus advance through the currently filtered+sorted list, `Enter`/blur commit, `Escape` cancel, silent no-op on empty/unchanged. Per-row sold-out `IconButton` opens a DS `Dialog` for confirmation. Filter chips (`All` / `In stock` / `Low` / `Sold out`) with reactive counts. `useMenu` gains an additive `updateMenuStock(menuID, quantity): Promise<boolean>` helper using bound SWR `mutate({ revalidate: false })` for optimistic writes; per-row request-id last-write-wins lives in `StockManager.tsx`.

## Changes

- `src/features/pocha/components/dashboard/StockManager.tsx` — full rewrite
  - Drops: `window.location.reload`, every `alert(...)`, `selectedMenu` / `customStock` / `isLoading` legacy state, "Reload Stock" button, all raw color classes (`bg-blue-500` / `bg-red-500` / `bg-green-500` / `bg-gray-300` / `text-white`), the `메뉴를 가져오는중...` Korean string, the `LoadingSpinner` legacy import.
  - DS atoms used: `Table` + `TableMobileList`/`TableMobileItem`, `ToggleGroup` (filter chips), `Input` (inline edit), `IconButton` (sold-out action), `Dialog` (confirm), `Skeleton` (loading), `StatusView` (error), `TableCaption` / `CardDescription` (filter-empty), `toast`, `Button` (toolbar refresh fallback — see Needs decision).
  - Race-safety: `useRef<Map<menuID, number>>` last-write-wins; stale `await` results dropped silently (no toast, no revert).
  - Inline-edit gesture identical across breakpoints (single tap on Stock cell → DS `Input`).
  - Filter chips: counts memoized over full `menuList`; default `All`.
- `src/features/pocha/hooks/useMenu.tsx` — additive
  - Adds `updateMenuStock(menuID: number, quantity: number): Promise<boolean>` helper.
  - Optimistic patch via bound SWR `mutate(updater, { revalidate: false })` (finds the row across all `MenuByCategory[]` entries and replaces `stock`).
  - On failure: rolls back via `mutate()` (full revalidate) and returns `false`.
  - Existing return shape `{ menuList, status, error, refetch }` is preserved — five existing consumers (`pocha/manage/page.tsx`, `MenuList.tsx`, `PreviousPochaDetailDialog.tsx`, `StockManager.tsx`, others) unaffected.

## Verification

- `npx tsc --noEmit` — no new errors (pre-existing `tsconfig.json` `TS5107` deprecation only).
- 1 `// pastiche-unresolved-doubt:` marker present at `StockManager.tsx:302` (refresh icon — see Needs decision).

## Scope tag

`[REDESIGN][NO-TDD]`

## Notes

DS docs gaps surfaced during pastiche execution (carried from skill `## Follow-ups`):

- `pastiche/KNOWLEDGE.md` — no scenario→atom mapping for "click-to-edit cell affordance" / "inline-edit cell trigger". The current implementation falls back to a raw `<button>` styled with `type-body` + a subtle hover background because `Button` variants are visually too heavy for a dense table cell. Consider adding a KNOWLEDGE entry such as "Inline-edit cell trigger → raw `<button>` styled with `type-body` + `hover:bg-brand-accent-subtle`" or designating an explicit DS atom.
- DS `Icon` registry — no refresh-class entry. See `## Needs decision` above.

Resolve by leaving a comment with the chosen option. Remove `needs-decision`, add `needs-revision` — the next routine revises (or, if Option 1 is chosen, just drop the marker line and flip to non-draft `ready-for-review`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc6Tj3iGZrfSC8FcnhbYPF)_