### PR TITLE
[Phase 3 / 3.9] REDESIGN: History tab — DS Table + ToggleGroup + Dialog with B-lite analytics

### DIFF
--- a/src/features/pocha/components/dashboard/OrderHistoryTable.tsx
+++ b/src/features/pocha/components/dashboard/OrderHistoryTable.tsx
@@ -1,21 +1,34 @@
-import React, { useState } from 'react';
+"use client";
 
-import useOrderHistory from '@/features/pocha/hooks/useOrderHistory';
-import LoadingSpinner from '@/components/ui/feedback/LoadingSpinner';
-import { calculateStripeTotalPrice } from '@/features/pocha/utils/calculateStripeFee';
+import { useMemo, useState } from "react";
 import {
-  calculateTotalSales,
-  calculateSummary,
-  convertOrderHistoryToMenuMap,
-} from '@/features/pocha/utils/orderHistoryUtils';
-import OrderSummaryModal from './OrderSummaryModal';
+  Button,
+  Skeleton,
+  StatusView,
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableMobileItem,
+  TableMobileList,
+  TableRow,
+  ToggleGroup,
+} from "@umichkisa-ds/web";
+
+import useOrderHistory from "@/features/pocha/hooks/useOrderHistory";
+import OrderSummaryModal from "./OrderSummaryModal";
 
 interface OrderHistoryTableProps {
   token: string;
   pochaID: number;
 }
 
-type FilterOption = 'all' | 'food' | 'drink';
+type FilterOption = "all" | "food" | "drink";
+
+const SKELETON_ROW_COUNT = 5;
+const COLUMN_COUNT = 7;
 
 export default function OrderHistoryTable({
   token,
@@ -23,137 +36,194 @@ export default function OrderHistoryTable({
 }: OrderHistoryTableProps) {
   const { orderHistory, status } = useOrderHistory(token, pochaID);
 
-  const [filter, setFilter] = useState<FilterOption>('all');
-
+  const [filter, setFilter] = useState<FilterOption>("all");
   const [openSummaryModal, setOpenSummaryModal] = useState<boolean>(false);
 
-  const menuMap = convertOrderHistoryToMenuMap(orderHistory);
+  const counts = useMemo(() => {
+    const list = orderHistory ?? [];
+    const food = list.filter(({ menu }) => !menu.isImmediatePrep).length;
+    const drink = list.filter(({ menu }) => menu.isImmediatePrep).length;
+    return { all: list.length, food, drink };
+  }, [orderHistory]);
 
-  const filteredOrderHistory = orderHistory?.filter(({ menu }) => {
-    if (filter === 'all') return true;
-    return filter === 'food' ? !menu.isImmediatePrep : menu.isImmediatePrep;
-  });
+  const filteredOrderHistory = useMemo(() => {
+    const list = orderHistory ?? [];
+    if (filter === "all") return list;
+    if (filter === "food") return list.filter(({ menu }) => !menu.isImmediatePrep);
+    return list.filter(({ menu }) => menu.isImmediatePrep);
+  }, [orderHistory, filter]);
 
-  if (status === 'loading') {
+  if (status === "loading") {
     return (
-      <LoadingSpinner fullScreen={false} label='주문 기록을 가져오는중...' />
+      <div className="w-full p-4">
+        <div className="hidden md:block">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>#</TableHead>
+                <TableHead>Menu</TableHead>
+                <TableHead>Category</TableHead>
+                <TableHead>Qty</TableHead>
+                <TableHead>Price</TableHead>
+                <TableHead>Total</TableHead>
+                <TableHead>Orderer email</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {Array.from({ length: SKELETON_ROW_COUNT }).map((_, rowIdx) => (
+                <TableRow key={`skeleton-row-${rowIdx}`}>
+                  {Array.from({ length: COLUMN_COUNT }).map((__, colIdx) => (
+                    <TableCell key={`skeleton-cell-${rowIdx}-${colIdx}`}>
+                      <Skeleton className="h-4 w-full" />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+        <div className="block md:hidden">
+          <TableMobileList>
+            {Array.from({ length: SKELETON_ROW_COUNT }).map((_, rowIdx) => (
+              <TableMobileItem key={`skeleton-mobile-${rowIdx}`}>
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-1/2" />
+              </TableMobileItem>
+            ))}
+          </TableMobileList>
+        </div>
+      </div>
     );
   }
 
-  if (status === 'error') {
-    throw new Error('Error fetching order history');
+  if (status === "error") {
+    return (
+      <StatusView variant="error" title="Failed to load order history." />
+    );
   }
 
-  if (!filteredOrderHistory) {
-    return <div>No order history found</div>;
+  if (!orderHistory || orderHistory.length === 0) {
+    return (
+      <StatusView variant="not-found" title="No order history." />
+    );
   }
+
+  const filterItems = [
+    { value: "all", label: `All (${counts.all})` },
+    { value: "food", label: `Food (${counts.food})` },
+    { value: "drink", label: `Drinks (${counts.drink})` },
+  ];
 
   return (
-    <div className='w-full'>
-      <div className='p-4 space-y-4'>
-        <div className='flex justify-between items-center mb-4'>
-          <div className='flex space-x-4'>
-            <button
-              onClick={() => setFilter('all')}
-              className={`px-4 py-2 ${
-                filter === 'all' ? 'bg-blue-500 text-white' : 'bg-gray-200'
-              }`}
-            >
-              전체
-            </button>
-            <button
-              onClick={() => setFilter('food')}
-              className={`px-4 py-2 ${
-                filter === 'food' ? 'bg-blue-500 text-white' : 'bg-gray-200'
-              }`}
-            >
-              안주
-            </button>
-            <button
-              onClick={() => setFilter('drink')}
-              className={`px-4 py-2 ${
-                filter === 'drink' ? 'bg-blue-500 text-white' : 'bg-gray-200'
-              }`}
-            >
-              주류
-            </button>
-          </div>
-          <button
+    <div className="w-full">
+      <div className="flex flex-col gap-4 p-4">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <ToggleGroup
+            items={filterItems}
+            value={filter}
+            onValueChange={(v) => setFilter(v as FilterOption)}
+            aria-label="Filter order history"
+          />
+          <Button
+            variant="primary"
             onClick={() => setOpenSummaryModal(true)}
-            className='px-4 py-2 bg-green-500 text-white'
           >
-            요약하기
-          </button>
-          {
-            openSummaryModal && (
-              <OrderSummaryModal
-                handleCloseForm={() => setOpenSummaryModal(false)}
-                orderHistory={orderHistory}
-              />
-            )
-          }
+            View summary
+          </Button>
         </div>
 
-        <table className='min-w-full divide-y divide-gray-200'>
-          <thead className='bg-gray-50'>
-            <tr className='text-sm text-black text-center'>
-              <th className='px-6 py-3 font-medium uppercase tracking-wider'>
-                Order #
-              </th>
-              <th className='px-6 py-3 font-medium uppercase tracking-wider'>
-                Item
-              </th>
-              <th className='px-6 py-3 font-medium uppercase tracking-wider'>
-                Quantity
-              </th>
-              <th className='px-6 py-3 font-medium uppercase tracking-wider'>
-                Price
-              </th>
-              <th className='px-6 py-3 font-medium uppercase tracking-wider'>
-                Price + Fee
-              </th>
-              <th className='px-6 py-3 font-medium uppercase tracking-wider'>
-                Customer
-              </th>
-              <th className='px-6 py-3 font-medium uppercase tracking-wider'>
-                Email
-              </th>
-            </tr>
-          </thead>
-          <tbody className='bg-white divide-y divide-gray-200'>
-            {filteredOrderHistory?.map(
-              (
-                { orderItemID, menu, quantity, ordererName, ordererEmail },
-                index
-              ) => (
-                <tr key={`${orderItemID}-${index}`} className='text-center'>
-                  <td className='px-6 py-4 whitespace-nowrap font-medium text-gray-900'>
-                    #{orderItemID}
-                  </td>
-                  <td className='px-6 py-4 whitespace-nowrap text-gray-500'>
-                    {menu.nameKor}
-                  </td>
-                  <td className='px-6 py-4 whitespace-nowrap text-gray-500'>
-                    {quantity}
-                  </td>
-                  <td className='px-6 py-4 whitespace-nowrap text-gray-500'>
-                    ${menu.price.toFixed(2)}
-                  </td>
-                  <td className='px-6 py-4 whitespace-nowrap text-gray-500'>
-                    ${calculateStripeTotalPrice(menu.price).toFixed(2)}
-                  </td>
-                  <td className='px-6 py-4 whitespace-nowrap text-gray-500'>
-                    {ordererName}
-                  </td>
-                  <td className='px-6 py-4 whitespace-nowrap text-gray-500'>
-                    {ordererEmail}
-                  </td>
-                </tr>
-              )
-            )}
-          </tbody>
-        </table>
+        <div className="hidden md:block">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>#</TableHead>
+                <TableHead>Menu</TableHead>
+                <TableHead>Category</TableHead>
+                <TableHead>Qty</TableHead>
+                <TableHead>Price</TableHead>
+                <TableHead>Total</TableHead>
+                <TableHead>Orderer email</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredOrderHistory.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={COLUMN_COUNT}
+                    className="text-center text-muted-foreground"
+                  >
+                    No items match this filter
+                  </TableCell>
+                </TableRow>
+              ) : (
+                filteredOrderHistory.map(
+                  ({ orderItemID, menu, quantity, ordererEmail }, index) => (
+                    <TableRow key={`${orderItemID}-${index}`}>
+                      <TableCell>{orderItemID}</TableCell>
+                      <TableCell>{menu.nameKor}</TableCell>
+                      <TableCell>{menu.category ?? "—"}</TableCell>
+                      <TableCell>{quantity}</TableCell>
+                      <TableCell>{`$${menu.price.toFixed(2)}`}</TableCell>
+                      <TableCell>{`$${(menu.price * quantity).toFixed(2)}`}</TableCell>
+                      <TableCell>{ordererEmail}</TableCell>
+                    </TableRow>
+                  )
+                )
+              )}
+            </TableBody>
+            <TableCaption className="sr-only">
+              Order history for the selected pocha
+            </TableCaption>
+          </Table>
+        </div>
+
+        <div className="block md:hidden">
+          {filteredOrderHistory.length === 0 ? (
+            <p className="type-body-sm text-muted-foreground text-center py-4">
+              No items match this filter
+            </p>
+          ) : (
+            <TableMobileList>
+              {filteredOrderHistory.map(
+                ({ orderItemID, menu, quantity, ordererEmail }, index) => (
+                  <TableMobileItem key={`mobile-${orderItemID}-${index}`}>
+                    <div className="flex items-center justify-between">
+                      <span className="type-label text-muted-foreground">
+                        {`#${orderItemID}`}
+                      </span>
+                      <span className="type-body-sm text-muted-foreground">
+                        {menu.category ?? "—"}
+                      </span>
+                    </div>
+                    <span className="type-body text-foreground">
+                      {menu.nameKor}
+                    </span>
+                    <div className="flex items-center justify-between">
+                      <span className="type-body-sm text-muted-foreground">
+                        {`Qty ${quantity} · $${menu.price.toFixed(2)}`}
+                      </span>
+                      <span className="type-body text-foreground">
+                        {`$${(menu.price * quantity).toFixed(2)}`}
+                      </span>
+                    </div>
+                    <span className="type-caption text-muted-foreground">
+                      {ordererEmail}
+                    </span>
+                  </TableMobileItem>
+                )
+              )}
+            </TableMobileList>
+          )}
+        </div>
       </div>
+
+      <OrderSummaryModal
+        open={openSummaryModal}
+        onOpenChange={setOpenSummaryModal}
+        pochaID={pochaID}
+        orderHistory={orderHistory}
+      />
     </div>
   );
 }

--- a/src/features/pocha/components/dashboard/OrderSummaryModal.tsx
+++ b/src/features/pocha/components/dashboard/OrderSummaryModal.tsx
@@ -1,67 +1,185 @@
-import React from 'react';
+"use client";
 
-import { sejongHospitalBold } from '@/utils/fonts/textFonts';
-import PochaCloseIcon from '@/components/ui/icon/PochaCloseIcon';
 import {
-  convertOrderHistoryToMenuMap,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@umichkisa-ds/web";
+
+import { OrderItem } from "@/types/pocha";
+import {
+  analyzeSojuSales,
+  calculateDrinkRankings,
+  calculateFoodRankings,
   calculateSummary,
   calculateTotalSales,
-} from '../../utils/orderHistoryUtils';
-import { HorizontalDivider } from '@/components/ui/divider';
-
-import { OrderItem } from '@/types/pocha';
+} from "../../utils/orderHistoryUtils";
 
 interface OrderSummaryModalProps {
-  handleCloseForm: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  pochaID: number;
   orderHistory: OrderItem[];
 }
-export default function OrderSummaryModal({
-  handleCloseForm,
-  orderHistory,
-}: OrderSummaryModalProps) {
-  const menuMap = convertOrderHistoryToMenuMap(orderHistory);
-  const { totalSales, anjuRevenue, drinkRevenue } =
-    calculateSummary(orderHistory);
 
-    console.log('menuMap', menuMap);
+interface KpiCardProps {
+  label: string;
+  value: string;
+}
+
+function KpiCard({ label, value }: KpiCardProps) {
   return (
-    <div className='fixed inset-0 z-[99999] bg-black/30'>
-      <div className='relative z-[100000] w-full h-full flex items-center justify-center p-4'>
-        <div className='relative bg-white rounded-lg shadow-md text-black border-2 border-[#71717A] w-full max-w-2xl max-h-[90vh] overflow-y-auto'>
-          {/* Header */}
-          <div className='flex items-center justify-between px-6 py-2 border-b border-gray-200'>
-            <h2 className={`text-xl ${sejongHospitalBold.className}`}>
-              주문 요약
-            </h2>
-            <button
-              className='p-2 hover:bg-gray-100 rounded-full transition-colors'
-              onClick={handleCloseForm}
-            >
-              <PochaCloseIcon size='large' />
-            </button>
-          </div>
+    <Card>
+      <CardContent className="flex flex-col gap-2">
+        <span className="type-caption text-muted-foreground">{label}</span>
+        <span className="type-h3 text-foreground">{value}</span>
+      </CardContent>
+    </Card>
+  );
+}
 
-          {/* Form Content */}
-          <div className='flex flex-col p-6 gap-4'>
-            <span>{`총 금액: $${totalSales}`}</span>
-            <span>{`안주 매출: $${anjuRevenue} | 주류 매출: $${drinkRevenue}`}</span>
-            <HorizontalDivider />
+interface RankingRowProps {
+  rank: number;
+  nameKor: string;
+  quantity: number;
+  revenue: number;
+}
 
-            {/* 메뉴 별 매출 */}
-            <ul className='flex flex-col gap-2'>
-              {Array.from(menuMap.values()).map(
-                ({ menu, quantity, totalRevenue }) => (
-                  <li key={`menu-revenue-summary-${menu.menuID}`}>
-                    <span>{menu.nameEng}</span>
-                    <span>{`수량: ${quantity}`}</span>
-                    <span>{` 매출: $${totalRevenue}`}</span>
-                  </li>
-                )
-              )}
-            </ul>
-          </div>
-        </div>
+function RankingRow({ rank, nameKor, quantity, revenue }: RankingRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex items-center gap-2">
+        <span className="type-label text-muted-foreground">{rank}</span>
+        <span className="type-body text-foreground">{nameKor}</span>
+      </div>
+      <div className="flex items-center gap-4">
+        <span className="type-body-sm text-muted-foreground">{`×${quantity}`}</span>
+        <span className="type-body text-foreground">{`$${revenue.toFixed(2)}`}</span>
       </div>
     </div>
+  );
+}
+
+export default function OrderSummaryModal({
+  open,
+  onOpenChange,
+  orderHistory,
+}: OrderSummaryModalProps) {
+  const hasHistory = orderHistory && orderHistory.length > 0;
+
+  const totalSales = hasHistory ? calculateTotalSales(orderHistory) : "0.00";
+  const { anjuRevenue, drinkRevenue } = hasHistory
+    ? calculateSummary(orderHistory)
+    : { anjuRevenue: "0.00", drinkRevenue: "0.00" };
+
+  const foodRankings = hasHistory ? calculateFoodRankings(orderHistory) : [];
+  const drinkRankings = hasHistory ? calculateDrinkRankings(orderHistory) : [];
+  const sojuAnalysis = hasHistory
+    ? analyzeSojuSales(orderHistory)
+    : { regular: 0, fruit: 0, total: 0 };
+
+  const formatPercent = (count: number, total: number): string =>
+    total > 0 ? ((count / total) * 100).toFixed(1) : "0.0";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="lg" className="max-h-[90vh] overflow-y-auto">
+        <DialogTitle>Order summary</DialogTitle>
+
+        {!hasHistory ? (
+          <p className="type-body text-muted-foreground">
+            No order history for this pocha.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-6">
+            {/* KPI row */}
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              <KpiCard label="Total revenue" value={`$${totalSales}`} />
+              <KpiCard label="Food revenue" value={`$${anjuRevenue}`} />
+              <KpiCard label="Drinks revenue" value={`$${drinkRevenue}`} />
+            </div>
+
+            {/* Top 3 food */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Top 3 food</CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-2">
+                {foodRankings.length === 0 ? (
+                  <span className="type-body-sm text-muted-foreground">
+                    No food sales.
+                  </span>
+                ) : (
+                  foodRankings.map((item, idx) => (
+                    <RankingRow
+                      key={`food-${idx}`}
+                      rank={idx + 1}
+                      nameKor={item.nameKor}
+                      quantity={item.quantity}
+                      revenue={item.revenue}
+                    />
+                  ))
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Top 3 drinks */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Top 3 drinks</CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-2">
+                {drinkRankings.length === 0 ? (
+                  <span className="type-body-sm text-muted-foreground">
+                    No drink sales.
+                  </span>
+                ) : (
+                  drinkRankings.map((item, idx) => (
+                    <RankingRow
+                      key={`drink-${idx}`}
+                      rank={idx + 1}
+                      nameKor={item.nameKor}
+                      quantity={item.quantity}
+                      revenue={item.revenue}
+                    />
+                  ))
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Soju breakdown */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Soju breakdown</CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <span className="type-body text-foreground">Regular</span>
+                  <span className="type-body text-foreground">
+                    {`${sojuAnalysis.regular} (${formatPercent(
+                      sojuAnalysis.regular,
+                      sojuAnalysis.total
+                    )}%)`}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="type-body text-foreground">Fruit</span>
+                  <span className="type-body text-foreground">
+                    {`${sojuAnalysis.fruit} (${formatPercent(
+                      sojuAnalysis.fruit,
+                      sojuAnalysis.total
+                    )}%)`}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
Closes #123

## Summary

Full DS-native rewrite of the History tab. `OrderHistoryTable.tsx` now renders the 7-column DS `Table` (with `TableMobileList` paired counterpart for ≤md viewports), DS `ToggleGroup` filter chips with memoized `All (N) / Food (N) / Drinks (N)` counts, and a `View summary` `Button` that opens a controlled `OrderSummaryModal` Dialog. `OrderSummaryModal.tsx` is rebuilt as a controlled DS `Dialog` housing four DS `Card` sections — KPI grid (Total / Food / Drinks revenue), Top-3 food, Top-3 drinks, and Soju regular/fruit breakdown — using semantic `type-*` typography and `text-foreground` / `text-muted-foreground` tokens throughout. All Korean strings, raw color classes, the bespoke fixed-inset overlay, and the dead `console.log('menuMap', menuMap)` are gone.

## Changes

- `src/features/pocha/components/dashboard/OrderHistoryTable.tsx` — full rewrite
  - Drops: `LoadingSpinner` import, `convertOrderHistoryToMenuMap` (unused call), Korean copy (`전체` / `안주` / `주류` / `요약하기` / `주문 기록을 가져오는중...`), all raw color classes (`bg-blue-500` / `bg-gray-200` / `bg-green-500` / `bg-gray-50` / `text-white` / `text-gray-500` / `text-gray-900` / `bg-white` / `divide-gray-200`), `throw new Error('Error fetching order history')`.
  - DS atoms used: `Table` + compounds (`TableHeader` / `TableBody` / `TableRow` / `TableHead` / `TableCell` / `TableCaption`), `TableMobileList` / `TableMobileItem` (mobile pairing), `ToggleGroup` (filter chips), `Button` (View summary trigger), `Skeleton` (loading rows), `StatusView` (error / empty).
  - 7 columns: `#`, `Menu` (`menu.nameKor`), `Category` (`menu.category ?? "—"`), `Qty`, `Price` (`$${menu.price.toFixed(2)}`), `Total` (`$${(menu.price * quantity).toFixed(2)}`), `Orderer email` (no truncation).
  - Filter counts memoized over the full `orderHistory` (not the filtered subset).
  - States: skeleton rows in both desktop and mobile loading; `StatusView variant="error"` titled `Failed to load order history.`; `StatusView variant="not-found"` titled `No order history.`; in-table caption row + mobile-list paragraph for filter-empty.
- `src/features/pocha/components/dashboard/OrderSummaryModal.tsx` — body rewrite (filename kept)
  - Drops: `PochaCloseIcon` import, `sejongHospitalBold` font, `HorizontalDivider`, `console.log('menuMap', menuMap)`, the bespoke fixed-inset overlay div tree, `handleCloseForm` callback prop.
  - New props: controlled `open` + `onOpenChange` + `pochaID` + `orderHistory`.
  - DS atoms: `Dialog` + `DialogContent` (size `lg`) + `DialogTitle`, `Card` + `CardHeader` + `CardTitle` + `CardContent`.
  - Body sections:
    1. **KPI row** — 3 `KpiCard`s: Total revenue, Food revenue (anjuRevenue), Drinks revenue (drinkRevenue).
    2. **Top 3 food** — `calculateFoodRankings(orderHistory)` rendered as `RankingRow`s (rank + nameKor + ×qty + $revenue).
    3. **Top 3 drinks** — `calculateDrinkRankings(orderHistory)` same shape.
    4. **Soju breakdown** — `analyzeSojuSales` regular vs fruit absolute counts + percentage.
  - Empty-history fallback: single line `No order history for this pocha.`.

## Verification

- `npx tsc --noEmit` — no new errors (pre-existing `tsconfig.json` `TS5107` deprecation only).
- No `console.log` in either file (`grep -n "console" ...` returns 0).
- No Korean strings remain in either file.
- No `// pastiche-unresolved-doubt:` markers in the diff.

## Scope tag

`[REDESIGN][NO-TDD]`

## Notes

DS docs gaps surfaced during pastiche execution (carried from skill `## Follow-ups`):

- `OrderHistoryTable.tsx:108` — `StatusView` has no `empty` variant in FACT/source; used `variant="not-found"` with custom title `No order history.`. KNOWLEDGE.md candidate: clarify which variant covers post-load "no rows yet" empty states (or surface the gap to add an `empty` variant in the DS).
- `OrderSummaryModal.tsx:90` — `DialogContent` uses `max-h-[90vh] overflow-y-auto` to scroll the analytics body when DS `size="lg"` is insufficient (lane bailout authorized). WISDOM.md candidate: explicit rule on whether viewport-unit max-heights on `DialogContent` are sanctioned, or add a built-in body-scroll affordance.
- **Sibling dead-code consumer:** `src/features/pocha/components/history/PochaHistoryTable.tsx:90` still passes the legacy `handleCloseForm` prop to `OrderSummaryModal`. Pastiche notes this file is imported by `pocha/history/page.tsx` but not actually rendered. `tsc --noEmit` is silent on the prop mismatch (likely `strict: false` in tsconfig allows the JSX prop drift). `next build` may surface it depending on the build's strict-prop checking. Either delete `PochaHistoryTable.tsx` (and its import in `pocha/history/page.tsx`) or migrate it to the new controlled props in a follow-up lane. Out of scope here — the lane's `## Files` is dashboard-only.

This PR can land alongside #132 (lane 3.5), #133 (lane 3.6 `needs-decision`), and #134 (lane 3.8 `needs-decision`) without ordering constraints — none of these touch the same files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc6Tj3iGZrfSC8FcnhbYPF)_