### PR TITLE
[Phase 4 / 4.4a] redesign: Cart UI to DS atoms

### DIFF
--- a/src/app/(pocha)/pocha/cart/page.tsx
+++ b/src/app/(pocha)/pocha/cart/page.tsx
@@ -1,24 +1,77 @@
 "use client";
 
-// UI
-import PochaBackHeading from "@/features/pocha/components/shared/PochaBackHeading";
-import PochaHorizontalDivider from "@/features/pocha/components/shared/PochaHorizontalDivider";
+import React from "react";
+import { useRouter } from "next/navigation";
+import {
+  Container,
+  IconButton,
+  Skeleton,
+  StatusView,
+  Button,
+} from "@umichkisa-ds/web";
+
 import EmptyCartAlert from "@/features/pocha/components/cart/EmptyCartAlert";
 import CartList from "@/features/pocha/components/cart/CartList";
 import CartTotalSummary from "@/features/pocha/components/cart/CartTotalSummary";
-import { LoadingSpinner } from "@/components/ui/feedback";
 import ProceedToPaymentButton from "@/features/pocha/components/cart/ProceedToPaymentButton";
-import { StatusView } from "@umichkisa-ds/web";
 
-// hooks
 import usePochaID from "@/features/pocha/hooks/usePochaID";
 import useCart from "@/features/pocha/hooks/useCart";
 import { useAuth } from "@/lib/auth/authContext";
 
+function CartPageHeader() {
+  const router = useRouter();
+
+  return (
+    <header className="relative flex items-center justify-center py-3">
+      <IconButton
+        icon="chevron-left"
+        aria-label="Back"
+        size="md"
+        variant="tertiary"
+        onClick={() => router.back()}
+        className="absolute left-2"
+      />
+      <h1 className="type-h3 text-foreground">Cart</h1>
+    </header>
+  );
+}
+
+function CartPageSkeleton() {
+  return (
+    <Container
+      as="section"
+      size="sm"
+      className="flex flex-col min-h-screen !gap-0"
+    >
+      <div className="relative flex items-center justify-center py-3">
+        <Skeleton className="h-6 w-16" />
+      </div>
+      <div className="flex flex-col divide-y divide-border">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <div key={idx} className="flex items-center gap-3 py-4">
+            <Skeleton variant="rectangular" className="h-20 w-20 rounded-md" />
+            <div className="flex flex-col gap-2 flex-1">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-4 w-1/3" />
+            </div>
+            <Skeleton className="h-8 w-24 rounded-md" />
+          </div>
+        ))}
+      </div>
+      <div
+        className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface px-4 pt-3"
+        style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 0.75rem)" }}
+      >
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    </Container>
+  );
+}
+
 export default function PochaCartPage() {
   const { session } = useAuth();
 
-  // get pochaID from URL or API to use in cart
   const {
     pochaID,
     status: pochaIDStatus,
@@ -26,13 +79,13 @@ export default function PochaCartPage() {
     noPocha,
   } = usePochaID();
 
-  // get cart items and total amount
   const {
     cart,
     status: cartStatus,
     error: cartError,
     totalAmount,
     handleQuantityChange,
+    fetchCart,
   } = useCart(session?.user?.email, pochaID);
 
   // Short-circuit before the loading check — useCart stalls on null pochaID,
@@ -43,42 +96,66 @@ export default function PochaCartPage() {
         fullScreen
         variant="not-found"
         icon="calendar"
-        title="진행 중인 포차가 없습니다"
+        title="No pocha in progress"
         description="다음 포차가 시작되면 장바구니를 사용할 수 있습니다."
       />
     );
   }
 
   if (pochaIDStatus === "loading" || cartStatus === "loading") {
-    return <LoadingSpinner />;
+    return <CartPageSkeleton />;
   }
 
   if (pochaIDStatus === "error" || cartStatus === "error") {
-    throw new Error(pochaIDError || cartError || "Unexpected error occurred");
+    return (
+      <Container
+        as="section"
+        size="sm"
+        className="flex flex-col min-h-screen !gap-0"
+      >
+        <CartPageHeader />
+        <StatusView
+          variant="error"
+          title="Could not load cart"
+          description={pochaIDError || cartError || "Please try again."}
+          action={
+            <Button variant="primary" onClick={() => fetchCart()}>
+              Retry
+            </Button>
+          }
+        />
+      </Container>
+    );
   }
 
-  return (
-    <section className="flex flex-col w-full min-h-screen !gap-0">
-      <PochaBackHeading title="Cart" />
-      <PochaHorizontalDivider />
+  const isEmpty = !cart || Object.keys(cart).length === 0;
 
-      {Object.keys(cart)?.length === 0 ? (
+  return (
+    <Container
+      as="section"
+      size="sm"
+      className="flex flex-col min-h-screen !gap-0"
+    >
+      <CartPageHeader />
+
+      {isEmpty ? (
         <EmptyCartAlert />
       ) : (
         <>
-          <div className="flex-grow">
+          <div className="flex-grow pb-40">
             <CartList cart={cart} handleQuantityChange={handleQuantityChange} />
           </div>
           <div
-            className="sticky bottom-0 self-stretch w-full
-           bg-white pb-4 gap-2 z-50"
+            className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface px-4 pt-3 flex flex-col gap-3"
+            style={{
+              paddingBottom: "calc(env(safe-area-inset-bottom) + 0.75rem)",
+            }}
           >
-            <PochaHorizontalDivider />
             <CartTotalSummary totalAmount={totalAmount} />
             <ProceedToPaymentButton pochaid={pochaID} />
           </div>
         </>
       )}
-    </section>
+    </Container>
   );
 }

--- a/src/app/(pocha)/pocha/cart/page.tsx
+++ b/src/app/(pocha)/pocha/cart/page.tsx
@@ -128,7 +128,9 @@ export default function PochaCartPage() {
     );
   }
 
-  const isEmpty = !cart || Object.keys(cart).length === 0;
+  const isEmpty =
+    !cart ||
+    Object.values(cart).every((item) => !item || item.quantity === 0);
 
   return (
     <Container

--- a/src/features/pocha/components/cart/CartList.tsx
+++ b/src/features/pocha/components/cart/CartList.tsx
@@ -12,7 +12,7 @@ export default function CartList({
   handleQuantityChange,
 }: CartListProps) {
   return (
-    <ul className="flex flex-col py-2 px-2">
+    <ul className="flex flex-col divide-y divide-border">
       {Object.entries(cart).map(([menuid, item]) => (
         <CartListItem
           key={menuid}

--- a/src/features/pocha/components/cart/CartListItem.tsx
+++ b/src/features/pocha/components/cart/CartListItem.tsx
@@ -1,11 +1,20 @@
+/**
+ * CartListItem
+ * - One row in the cart list. Mobile-only.
+ * - Quantity stepper: at qty=1 the decrement icon swaps to a "remove" affordance
+ *   (single remove path is decrement-to-zero; no separate X button).
+ * - When quantity === menu.stock, the `+` is disabled and an inline red `Max`
+ *   hint shows on the row.
+ */
+
 import React from "react";
-import { sejongHospitalBold } from "@/utils/fonts/textFonts";
 import Image from "next/image";
+import { IconButton } from "@umichkisa-ds/web";
 import { CartItem } from "@/types/pocha";
-import PochaMinusIcon from "@/components/ui/icon/PochaMinusIcon";
-import PochaPlusIcon from "@/components/ui/icon/PochaPlusIcon";
-import PochaTrashIcon from "@/components/ui/icon/PochaTrashIcon";
-import { getMenuImagePath } from "@/features/pocha/utils/getImagePath";
+import {
+  defaultImageURL,
+  getMenuImagePath,
+} from "@/features/pocha/utils/getImagePath";
 
 type CartListItemProps = {
   item: CartItem;
@@ -18,84 +27,82 @@ export default function CartListItem({
   menuid,
   handleQuantityChange,
 }: CartListItemProps) {
+  if (!item || item.quantity === 0) {
+    return null;
+  }
+
+  const { menu, quantity } = item;
+  const atStockCap = quantity >= menu.stock;
+  const lineTotal = menu.price * quantity;
+
   const incrementQuantity = () => {
+    if (atStockCap) return;
     handleQuantityChange(menuid, 1);
   };
 
   const decrementQuantity = () => {
-    // Default quantity starts at 1.
-    if (item.quantity > 0) {
-      handleQuantityChange(menuid, -1);
-    }
+    handleQuantityChange(menuid, -1);
   };
 
-  const removeItemFromCart = () => {
-    handleQuantityChange(menuid, -item.quantity);
-  };
-
-  if (!item || item.quantity === 0) {
-    return <></>;
-  }
-
+  // pastiche-unresolved-doubt: server stock-reject inline-red treatment ({ isStocked: false } from changeItemInCart) cannot be surfaced from this row without modifying useCart.handleQuantityChange — useCart is out of `## Files` for lane 4.4a. Defer to lane 4.4b or expand 4.4a scope.
   return (
-    <li className="flex items-center py-4 border-b border-[#CACACA]">
-      <figure className="relative h-[5rem] w-[5rem] flex-shrink-0 rounded-full border-gray-300 shadow-md">
+    <li className="flex items-center py-4 gap-3">
+      <figure className="relative h-20 w-20 flex-shrink-0">
         <Image
-          src={getMenuImagePath(menuid)}
-          alt={item.menu.nameEng}
+          src={getMenuImagePath(menuid) || defaultImageURL}
+          alt={menu.nameEng}
           fill
-          sizes="(max-width: 768px) 20vw"
-          className="rounded-[15px] border-gray-300 object-cover"
+          sizes="80px"
+          className="rounded-md border-border object-cover"
         />
       </figure>
 
-      <div className="flex flex-col flex-grow gap-1 ml-3">
-        <span className={`${sejongHospitalBold.className} text-black`}>
-          {item?.menu?.nameKor} {item?.menu?.nameEng}
+      <div className="flex flex-col flex-grow gap-1 min-w-0">
+        <span className="type-body text-foreground truncate">
+          {menu.nameKor} · {menu.nameEng}
         </span>
-        <span className={`${sejongHospitalBold.className} text-gray-500`}>
-          ${(item?.menu?.price * item.quantity).toFixed(2)}
+        <span className="type-body-sm text-muted-foreground">
+          ${menu.price.toFixed(2)} × {quantity} · ${lineTotal.toFixed(2)}
         </span>
+        {atStockCap && (
+          <span className="type-caption text-error">
+            Max · 재고 {menu.stock}개
+          </span>
+        )}
       </div>
 
-      {/* counter logic */}
-      <div
-        className="flex items-center justify-between ml-1
-      border-2 border-[#CACACA] rounded-full shadow-md
-      px-[0.65rem] py-[0.2rem] gap-[1rem]"
-      >
-        {/* Decrement Button */}
-        {item.quantity > 1 ? (
-          <button
-            className={`${sejongHospitalBold.className}  rounded-full `}
+      <div className="flex items-center gap-2 flex-shrink-0">
+        {quantity > 1 ? (
+          <IconButton
+            icon="minus"
+            aria-label="Decrease quantity"
+            size="sm"
+            variant="secondary"
             onClick={decrementQuantity}
-          >
-            <PochaMinusIcon size="small" />
-          </button>
+          />
         ) : (
-          <button
-            onClick={removeItemFromCart}
-            className=" 
-             rounded-full"
-          >
-            <PochaTrashIcon size="small" />
-          </button>
+          <IconButton
+            icon="trash-2"
+            aria-label="Remove from cart"
+            size="sm"
+            variant="secondary"
+            onClick={decrementQuantity}
+          />
         )}
-
-        {/* Quantity Display */}
         <span
-          className={`${sejongHospitalBold.className} font-semibold text-black`}
+          className="type-body text-foreground w-6 text-center"
+          aria-live="polite"
         >
-          {item.quantity}
+          {quantity}
         </span>
-
-        {/* Increment Button */}
-        <button
+        <IconButton
+          icon="plus"
+          aria-label="Increase quantity"
+          size="sm"
+          variant="secondary"
           onClick={incrementQuantity}
-          className={`${sejongHospitalBold.className}   rounded-full`}
-        >
-          <PochaPlusIcon size="small" />
-        </button>
+          disabled={atStockCap}
+        />
       </div>
     </li>
   );

--- a/src/features/pocha/components/cart/CartTotalSummary.tsx
+++ b/src/features/pocha/components/cart/CartTotalSummary.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { sejongHospitalBold } from "@/utils/fonts/textFonts";
 
 interface CartTotalSummaryProps {
   totalAmount: number;
@@ -9,12 +8,11 @@ export default function CartTotalSummary({
   totalAmount,
 }: CartTotalSummaryProps) {
   return (
-    <div
-      className={`flex justify-between w-full py-4 
-    ${sejongHospitalBold.className} text-lg text-black`}
-    >
-      <span>Total</span>
-      <span className={``}>${totalAmount}</span>
+    <div className="flex justify-between items-baseline w-full">
+      <span className="type-body text-muted-foreground">Total</span>
+      <span className="type-h3 text-foreground">
+        ${Number(totalAmount).toFixed(2)}
+      </span>
     </div>
   );
 }

--- a/src/features/pocha/components/cart/EmptyCartAlert.tsx
+++ b/src/features/pocha/components/cart/EmptyCartAlert.tsx
@@ -1,19 +1,19 @@
-import { sejongHospitalBold } from "@/utils/fonts/textFonts";
 import Image from "next/image";
 import React from "react";
 
 export default function EmptyCartAlert() {
   return (
-    <div className="flex flex-col justify-center items-center">
+    <div className="flex flex-col justify-center items-center py-12 gap-4">
       <Image
-        src={`/images/empty_cart.png`}
-        alt="Empty Cart Icon"
-        width={300}
-        height={300}
+        src="/images/empty_cart.png"
+        alt=""
+        width={240}
+        height={240}
+        aria-hidden="true"
       />
-      <div className={`${sejongHospitalBold.className} text-center mt-4`}>
-        Your Cart is Empty
-      </div>
+      <p className="type-body text-foreground text-center">
+        Your cart is empty.
+      </p>
     </div>
   );
 }

--- a/src/features/pocha/components/cart/ProceedToPaymentButton.tsx
+++ b/src/features/pocha/components/cart/ProceedToPaymentButton.tsx
@@ -1,19 +1,26 @@
 import React from "react";
-import PochaButton from "../shared/PochaButton";
+import { useRouter } from "next/navigation";
+import { Button } from "@umichkisa-ds/web";
 
 type PaymentProps = {
   pochaid: number;
 };
 
 export default function ProceedToPaymentButton({ pochaid }: PaymentProps) {
+  const router = useRouter();
+
   const handlePaymentClick = () => {
-    const queryParams = `pochaid=${pochaid}`;
-    window.location.href = `/pocha/pay?${queryParams}`;
+    router.push(`/pocha/pay?pochaid=${pochaid}`);
   };
 
   return (
-    <div className="w-full flex justify-center">
-      <PochaButton label="Checkout" onClick={handlePaymentClick} />
-    </div>
+    <Button
+      variant="primary"
+      size="lg"
+      onClick={handlePaymentClick}
+      className="w-full"
+    >
+      Proceed to payment
+    </Button>
   );
 }


### PR DESCRIPTION
Closes #142

## Needs decision

**Stuck on:** Surfacing the post-mutation server stock-reject (`{ isStocked: false }` from `changeItemInCart`) as inline red on a cart row requires modifying `useCart.handleQuantityChange` to forward the reject signal back to the caller — but `useCart.ts` is outside this lane's `## Files`.

**What I attempted:**
- Implemented the local stock cap end-to-end: when `quantity === menu.stock`, the `+` `IconButton` is disabled and an inline red `Max · 재고 N개` hint renders on the row (matches `MenuListItem`'s vocabulary).
- Did not invent a parallel mutation path from the row (would duplicate the API call and contradict `useCart`'s debounced/optimistic contract).
- Inserted a single `// pastiche-unresolved-doubt:` marker at `src/features/pocha/components/cart/CartListItem.tsx:47` rather than silently dropping the server-reject UX.

**What's unclear:** Where should the server-reject inline-red treatment land?

**Options:**
1. **Defer to lane 4.4b.** 4.4b's `## Files` already includes `useCart.ts` (additive). 4.4b extends `handleQuantityChange` to return / call back the reject signal, and the row reads it. — tradeoff: cleanest scope split; the cap-only behavior ships in 4.4a, the server-reject UX trails by one lane.
2. **Expand 4.4a scope.** Add `src/features/pocha/hooks/useCart.ts` to this lane's `## Files`, then ship the inline-red server-reject here. — tradeoff: tighter UX bundling but spec drift on `## Files`.
3. **Accept the gap.** Ship cap-only and skip the server-reject inline UX entirely. — tradeoff: drops a documented spec item; users see optimistic update + silent revert via `fetchCart` on race.

**My weak preference:** Option 1 — keeps each lane scope-pure and 4.4b already touches `useCart.ts`.

## Summary

Rebuilds `/pocha/cart` on `@umichkisa-ds/web` atoms per Lane 4.4a spec. Drops `PochaBackHeading` / `PochaHorizontalDivider` / `PochaButton` / `LoadingSpinner` imports. Replaces raw `sejongHospitalBold` and color/size utilities with `type-*` and semantic tokens. The stepper uses `IconButton` (`minus` / `plus`, with `trash-2` swapped in at `qty=1`). Sticky bottom dock (total + `Proceed to payment` via `router.push`) respects `env(safe-area-inset-bottom)` and is hidden when the cart is empty. Loading is a skeleton (header + 3 rows + dock placeholder); error replaces the legacy `throw new Error` with an inline `StatusView` + `Retry` calling `fetchCart()`. Empty state keeps the existing PNG illustration with English-only copy and no CTA.

## Changes

- `src/app/(pocha)/pocha/cart/page.tsx` — rebuild shell: local back-chevron header, `Container` wrapper, skeleton loading state, inline `StatusView` error surface with retry, sticky bottom dock with `CartTotalSummary` + `ProceedToPaymentButton`. Drops `PochaBackHeading`, `PochaHorizontalDivider`, `LoadingSpinner` imports.
- `src/features/pocha/components/cart/CartList.tsx` — `divide-y divide-border` row separator (matches `MenuList`).
- `src/features/pocha/components/cart/CartListItem.tsx` — DS `IconButton` stepper, `nameKor · nameEng`, compact line `$X.XX × N · $Y.YY`, `quantity === stock` cap with inline red `Max · 재고 N개` on the row. Drops `PochaMinusIcon` / `PochaPlusIcon` / `PochaTrashIcon` / `sejongHospitalBold`.
- `src/features/pocha/components/cart/CartTotalSummary.tsx` — `type-h3` total + `type-body` `Total` label; drops `sejongHospitalBold`.
- `src/features/pocha/components/cart/EmptyCartAlert.tsx` — keep PNG illustration, English-only `Your cart is empty.`, no CTA, drops `sejongHospitalBold`.
- `src/features/pocha/components/cart/ProceedToPaymentButton.tsx` — DS `Button` (primary, lg, `w-full`), navigation via `router.push`. Drops `PochaButton`.

## Verification

- `npx tsc --noEmit` — clean (only the pre-existing `tsconfig.json` `moduleResolution=node10` deprecation warning, unrelated).
- `// pastiche-unresolved-doubt:` scan — **1 marker** at `src/features/pocha/components/cart/CartListItem.tsx:47` (intentional; see "Needs decision" above).
- Manual smoke (mock mode) **deferred** to live review; this PR is draft + `needs-decision`.

## Scope tag

`[REDESIGN][NO-TDD]` · `autonomous-ready` (issue), bailing to **`needs-decision`** per AUTONOMOUS_PROTOCOL.md §8 (one unresolved-doubt marker present).

## Current state

Branch: `ds-client-migration/phase-4/4.4a-cart-ui` · Files: 6 modified · CI: pending

## Notes

Carried forward for reviewer attention:

- `src/features/pocha/components/cart/CartListItem.tsx:47` — server-reject inline-red UX gap (see "Needs decision"). Resolve by removing the marker + wiring up the chosen option.
- `useCart.updateQuantityUI` (`src/features/pocha/hooks/useCart.ts:49-63`, pre-existing) computes `prevCart[menuid].quantity + newQuantity` and assumes `prevCart[menuid]` exists. For the menu-detail "add to cart" flow the row may not exist yet, so this currently relies on the server round-trip + `fetchCart` reconciliation to backfill. Pre-existing behavior; flagging only — not in this lane's scope and not introduced by this PR.

To resolve: leave a comment with the chosen option above. Remove `needs-decision`, add `needs-revision` — next routine revises.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TZuj5edJyFJ5SS1tcYS3ut)_