### PR TITLE
Phase 4 follow-ups: toast over alert + MockAuthToggle dynamic-import

### DIFF
--- a/src/app/(pocha)/pocha/layout.tsx
+++ b/src/app/(pocha)/pocha/layout.tsx
@@ -1,12 +1,24 @@
 'use client';
 
 import { ReactNode } from 'react';
+import dynamic from 'next/dynamic';
 import { SessionProvider } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
 import { AuthContextProvider, useAuth } from '@/lib/auth/authContext';
-import { MockAuthToggle } from '@/mocks/MockAuthToggle';
 import { OnlyMobileView, StatusView } from '@umichkisa-ds/web';
 import LoginButton from '@/components/layout/header/LoginButton';
+
+// Dev-only toggle. Build-time gate: when NEXT_PUBLIC_MOCK_API !== "1",
+// the ternary collapses to null and the entire MockAuthToggle module
+// (plus its `/_mock/spawn-order/` strings) is tree-shaken from the prod
+// pocha layout chunk.
+const IS_MOCK_MODE = process.env.NEXT_PUBLIC_MOCK_API === '1';
+const MockAuthToggle = IS_MOCK_MODE
+  ? dynamic(
+      () => import('@/mocks/MockAuthToggle').then((m) => m.MockAuthToggle),
+      { ssr: false }
+    )
+  : null;
 
 // In mock mode the next-auth middleware is a no-op (see middleware.ts), so
 // /pocha/* routes only get gated client-side. This wraps every /pocha page
@@ -48,7 +60,7 @@ export default function PochaLayout({ children }) {
             </OnlyMobileView>
           )}
         </PochaAuthGate>
-        <MockAuthToggle />
+        {MockAuthToggle && <MockAuthToggle />}
       </AuthContextProvider>
     </SessionProvider>
   );

--- a/src/features/pocha/hooks/useStripePayment.ts
+++ b/src/features/pocha/hooks/useStripePayment.ts
@@ -1,6 +1,7 @@
 // hooks/useStripePayment.ts
 import { FormEvent, useState } from "react";
 import { useStripe, useElements } from "@stripe/react-stripe-js";
+import { toast } from "@umichkisa-ds/web";
 import { checkCartStock, notifyPayResult } from "@/apis/pocha/mutations";
 import { useRouter } from "next/navigation";
 import { ageGateResolve } from "../utils/ageGateResolve";
@@ -146,11 +147,11 @@ const useStripePayment = (
         throw new Error("Error while updating cart status");
       }
 
-      alert("결제가 완료되었습니다.");
+      toast.success("결제가 완료되었습니다.");
 
       router.push(`/pocha/pay-success?pochaid=${pochaID}&amount=${totalPrice}`);
     } catch (error) {
-      alert("결제 오류가 발생했습니다. 카드 정보를 확인해주세요");
+      toast.error("결제 오류가 발생했습니다. 카드 정보를 확인해주세요");
       setErrorMessage(error.message || "결제 실패");
       // notify pay result with failure
       const res = await notifyPayResult(userEmail, pochaID, {


### PR DESCRIPTION
## Summary
Phase 4 follow-up cleanups, dev → main.

- **F2** — `useStripePayment` replaces `alert()` calls with DS `toast.success` / `toast.error` for payment success and failure surfaces. Fixes a predictability smell flagged in the phase-4 Toss FE review (`alert` was mixing with `toast` elsewhere in the same flow).
- **MockAuthToggle dynamic-import** — wraps `MockAuthToggle` in `next/dynamic` behind a build-time `NEXT_PUBLIC_MOCK_API === '1'` gate. When the flag is not set (prod), the constant collapses to `null` at build time and the dev-only toggle module (incl. its `/_mock/spawn-order/` URL strings + simulate handlers) is no longer pulled into the pocha layout chunk.

## Verification
- **Bundle check (prod build)**:
  - Before: pocha layout chunk (`2656-…js`, ~few KB) contained `MockAuthToggle`, `spawn-order`, `Simulate promote`.
  - After: pocha layout chunk (`layout-1102a26222f90f6f.js`) — clean. MockAuthToggle moved to a separate dynamic chunk (`5951-…js`) that is never requested at runtime when the gate is off.
- `NEXT_PUBLIC_MOCK_API=0 npm run build` clean.
- `npm test` — 167 passed, 3 skipped.

## Deferred (intentionally NOT in this PR)
- **F1** — `useStripePayment.processPayment` 110-line refactor (extract Stripe API calls into `apis/stripe/`, split mock vs prod paths). Deferred until real-Stripe smoke is possible (no Stripe dashboard access right now); refactoring without runtime verification on the actual payment flow is too risky.

## Test plan
- [ ] After merge, smoke `/pocha/pay` mock-mode end-to-end — verify success toast renders (no `alert`).
- [ ] Force a mock failure path (e.g., toggle underage) — verify error toast renders.
- [ ] Verify `MockAuthToggle` UI does NOT render on prod env.
