### PR TITLE
fix(pocha): mock-only auth gate (no prod login-wall flicker)

### DIFF
--- a/src/app/(pocha)/pocha/layout.tsx
+++ b/src/app/(pocha)/pocha/layout.tsx
@@ -20,10 +20,13 @@ const MockAuthToggle = IS_MOCK_MODE
     )
   : null;
 
-// In mock mode the next-auth middleware is a no-op (see middleware.ts), so
-// /pocha/* routes only get gated client-side. This wraps every /pocha page
-// with a single auth check; admin pages keep their own role gate on top.
-function PochaAuthGate({ children }: { children: ReactNode }) {
+// Mock-only auth gate. In prod, next-auth middleware (`src/middleware.ts`)
+// gates `/pocha/:path*` server-side — any request that reaches a /pocha
+// page is already authenticated, so a client-side gate would just flicker
+// the "not logged in" StatusView during the next-auth session-loading
+// window. In mock mode the middleware is a no-op, so /pocha/* routes need
+// this client-side fallback. Admin pages keep their own role gate on top.
+function MockAuthGate({ children }: { children: ReactNode }) {
   const { isAuthenticated } = useAuth();
   const pathname = usePathname();
 
@@ -48,18 +51,20 @@ export default function PochaLayout({ children }) {
   const isDashboard = pathname.includes('/dashboard');
   const isManage = pathname.includes('/manage');
   const isHistory = pathname.includes('/history');
+
+  const body =
+    isDashboard || isManage || isHistory ? (
+      <div className='w-full'>{children}</div>
+    ) : (
+      <OnlyMobileView className='h-full overflow-visible'>
+        {children}
+      </OnlyMobileView>
+    );
+
   return (
     <SessionProvider>
       <AuthContextProvider initialSession={null}>
-        <PochaAuthGate>
-          {isDashboard || isManage || isHistory ? (
-            <div className='w-full'>{children}</div>
-          ) : (
-            <OnlyMobileView className='h-full overflow-visible'>
-              {children}
-            </OnlyMobileView>
-          )}
-        </PochaAuthGate>
+        {IS_MOCK_MODE ? <MockAuthGate>{body}</MockAuthGate> : body}
         {MockAuthToggle && <MockAuthToggle />}
       </AuthContextProvider>
     </SessionProvider>


### PR DESCRIPTION
## Summary
Drop the client-side `/pocha` auth gate in prod and rename it to `MockAuthGate`.

## Problem (observed on prod)
Hitting any `/pocha` route, the `<StatusView variant="not-logged-in">` flickered for a frame before the real content rendered. Repro: cold-load `/pocha` while signed in.

## Root cause
`PochaAuthGate` checked `useAuth().isAuthenticated`, which derives from `liveSession = nextAuthSession ?? initialSession`. The layout passes `initialSession={null}` (no `getServerSession()` seed), and on the first client render `useSession()` is still `{ status: 'loading', data: undefined }` — so `isAuthenticated` is `false` for one frame, the gate renders the login wall, then the session resolves and the real content swaps in.

In prod this gate is structurally redundant: `src/middleware.ts:22-28` already gates `/pocha/:path*` server-side via next-auth `withAuth`. Any request that reaches a /pocha page is authed. The client gate exists only because `middleware.ts` is a no-op in mock mode (the build-time `IS_MOCK_MODE` ternary wraps `withAuth`).

## Fix
- Rename `PochaAuthGate` → `MockAuthGate` (the name now matches what it actually is).
- Mount the gate only when `NEXT_PUBLIC_MOCK_API === '1'`. In prod the build-time-inlined ternary skips the gate entirely.
- Mock-mode behavior preserved: client gate still wraps every /pocha page, admin pages keep their own role gate on top.

## Verification
- `NEXT_PUBLIC_MOCK_API=0 npm run build` clean.
- `npm test` — 167 passed, 3 skipped.

## Test plan
- [ ] Prod: cold-load `/pocha` while signed in — no login-wall flicker.
- [ ] Prod: hit `/pocha` while signed out — middleware redirects to `/signin` (server-side).
- [ ] Mock: cold-load `/pocha` with `MockAuthToggle` off — login-wall renders (gate still active).
- [ ] Mock: toggle `MockAuthToggle` on — gate releases, content shows.
