### PR TITLE
chore(deps): bump axios to 1.15.2 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@vercel/analytics": "1.3.1",
         "@vercel/speed-insights": "^1.3.1",
         "aws-sdk": "^2.1496.0",
-        "axios": "1.12.0",
+        "axios": "1.15.2",
         "class-variance-authority": "^0.7.1",
         "cloudinary": "2.7.0",
         "clsx": "2.1.0",
@@ -14348,14 +14348,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -20055,10 +20055,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@vercel/analytics": "1.3.1",
     "@vercel/speed-insights": "^1.3.1",
     "aws-sdk": "^2.1496.0",
-    "axios": "1.12.0",
+    "axios": "1.15.2",
     "class-variance-authority": "^0.7.1",
     "cloudinary": "2.7.0",
     "clsx": "2.1.0",


### PR DESCRIPTION
## Summary
- Bumps `axios` from `1.12.0` to `1.15.2` to clear 14 open Dependabot alerts (3 high, 10 medium, 1 low).
- Fixes alerts #150-#162 plus #144, #140 (full list: prototype pollution gadgets in HTTP adapter / `validateStatus` / `withXSRFToken` / `parseReviver`, header injection, NO_PROXY/SSRF bypasses incl. RFC 1122 loopback, CRLF in `multipart/form-data`, `maxBodyLength`/`maxContentLength` bypasses, `toFormData` recursion DoS, null-byte injection in `AxiosURLSearchParams`).

## API compatibility
The repo uses only stable axios surface that is unchanged between 1.12 and 1.15:
- `axios.create({ baseURL, headers })` in `src/lib/axios/client.ts`
- `client.get/post/put/delete` across `src/apis/*`
- `AxiosError` instance check in `src/lib/axios/errorHandling.ts`
- `axios.isAxiosError(error)` in `src/apis/jobs/queries.ts`
- `AxiosError<T>` generic in `src/lib/axios/types.ts`

No call sites were modified. `npx tsc --noEmit` is clean; `npm run lint` shows only pre-existing warnings unrelated to this change.

## Not included in this PR (deliberate)
These open alerts only have major-version patches and should be handled in dedicated PRs:
- `next` 14.2.35 -> 15.5.15 (App Router breaking changes)
- `nodemailer` 6.9.9 -> 8.0.5
- `postcss` (transitive via `next`; resolved by the next.js major bump)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` shows no new warnings/errors
- [ ] Smoke test API calls against backend (reviewer to verify; PR author has no local backend access)
- [ ] Confirm Dependabot closes the 14 axios alerts after merge