### PR TITLE
[Phase 6 / 6.5b] MECHANICAL: MSW posts CRUD handlers + fixtures

### DIFF
--- a/src/mocks/fixtures/posts.ts
+++ b/src/mocks/fixtures/posts.ts
@@ -1,0 +1,110 @@
+import { BoardType } from "@/types/board";
+import type { Post } from "@/types/post";
+
+export const MOCK_USER_EMAIL = "tester@umich.edu";
+const OTHER_USER_EMAIL = "someone-else@umich.edu";
+
+/**
+ * Posts fixture for /posts CRUD endpoints.
+ *
+ * Cross-lane contract — postid range:
+ *   - 10000–10099 reserved for these full-body Post fixtures
+ *   - 10000 is authored by MOCK_USER_EMAIL (tester) for author-update tests
+ *   - 10001 is authored by OTHER_USER_EMAIL (admin-override tests)
+ *   - Lanes 6.5c (comments) and 6.5d (likes) reference these postids
+ *
+ * Note: this fixture is independent from `mockBoardPosts` in
+ * `fixtures/boards.ts` — Lane 6.5a's list-view fixture and this lane's
+ * full-body fixture happen to overlap in id range but the GET endpoints
+ * read from their own fixtures.
+ */
+const _posts: Post[] = [
+  {
+    postid: 10000,
+    title: "오늘 학식 너무 짠데 저만 그래요?",
+    created: "2026-04-01T12:00:00",
+    type: BoardType.Community,
+    fullname: "KISA Tester",
+    email: MOCK_USER_EMAIL,
+    readCount: 100,
+    commentsCount: 4,
+    anonymous: false,
+    likesCount: 12,
+    text: "이번 학기 학식이 유독 짜요. 저만 그런가요? 동의하시는 분 댓글 부탁드립니다.",
+    isAnnouncement: false,
+  },
+  {
+    postid: 10001,
+    title: "MacBook Air M2 판매합니다",
+    created: "2026-04-02T15:30:00",
+    type: BoardType.BuyAndSell,
+    fullname: "박서연",
+    email: OTHER_USER_EMAIL,
+    readCount: 250,
+    commentsCount: 7,
+    anonymous: false,
+    likesCount: 5,
+    text: "MacBook Air M2 256GB 판매합니다. 구매 1년 됐고 깨끗하게 사용했습니다. $850.",
+    isAnnouncement: false,
+  },
+  {
+    postid: 10002,
+    title: "EECS 281 시험 후기",
+    created: "2026-04-05T09:00:00",
+    type: BoardType.Academic,
+    fullname: "익명",
+    email: "anon-poster@umich.edu",
+    readCount: 320,
+    commentsCount: 15,
+    anonymous: true,
+    likesCount: 22,
+    text: "이번 281 시험 너무 빡셌어요... 평균 컷 어떻게 될지 궁금합니다.",
+    isAnnouncement: false,
+  },
+  {
+    postid: 10003,
+    title: "[필독] 2026 학생회 임원 명단",
+    created: "2026-01-15T09:00:00",
+    type: BoardType.Announcement,
+    fullname: "학생회",
+    email: "kisa-admin@umich.edu",
+    readCount: 850,
+    commentsCount: 0,
+    anonymous: false,
+    likesCount: 50,
+    text: "2026년 학생회 임원 명단을 공유드립니다. 회장: ..., 부회장: ...",
+    isAnnouncement: true,
+  },
+  {
+    postid: 10004,
+    title: "Forest Hills 1bed 룸메이트 구함",
+    created: "2026-04-10T14:00:00",
+    type: BoardType.Housing,
+    fullname: "이민준",
+    email: "minjunl@umich.edu",
+    readCount: 80,
+    commentsCount: 3,
+    anonymous: false,
+    likesCount: 1,
+    text: "Forest Hills 1bed 1bath 룸메이트 구합니다. 월 $700, 6월 입주.",
+    isAnnouncement: false,
+  },
+];
+
+export type PostsStore = Map<number, Post>;
+
+let store: PostsStore = new Map(_posts.map((p) => [p.postid, p]));
+let nextId = 20000;
+
+export function getPostsStore(): PostsStore {
+  return store;
+}
+
+export function nextPostId(): number {
+  return nextId++;
+}
+
+export function resetPostsStore(): void {
+  store = new Map(_posts.map((p) => [p.postid, { ...p }]));
+  nextId = 20000;
+}

--- a/src/mocks/handlers/__tests__/posts.test.ts
+++ b/src/mocks/handlers/__tests__/posts.test.ts
@@ -1,0 +1,229 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { setupServer } from "msw/node";
+import { postsHandlers, resetPostsStore } from "../posts";
+import { BoardType } from "@/types/board";
+
+const server = setupServer(...postsHandlers);
+
+const ADMIN_KEY = "kisa-mock-auth-isadmin";
+const AUTH_HEADER = { Authorization: "Bearer mock-access-token" };
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+const MOCK_USER_EMAIL = "tester@umich.edu";
+const OTHER_USER_EMAIL = "someone-else@umich.edu";
+
+const newCommunityPost = (overrides?: Partial<Record<string, unknown>>) => ({
+  type: BoardType.Community,
+  title: "Test post",
+  fullname: "KISA Tester",
+  email: MOCK_USER_EMAIL,
+  text: "Body text",
+  isAnnouncement: false,
+  anonymous: false,
+  readCount: 0,
+  ...overrides,
+});
+
+const newAnnouncementPayload = (overrides?: Partial<Record<string, unknown>>) => ({
+  type: BoardType.Announcement,
+  title: "공지사항",
+  fullname: "Admin User",
+  email: MOCK_USER_EMAIL,
+  text: "Important announcement",
+  isAnnouncement: true,
+  anonymous: false,
+  readCount: 0,
+  ...overrides,
+});
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+beforeEach(() => sessionStorage.removeItem(ADMIN_KEY));
+afterEach(() => {
+  server.resetHandlers();
+  resetPostsStore();
+  sessionStorage.removeItem(ADMIN_KEY);
+});
+afterAll(() => server.close());
+
+describe("MSW posts handlers", () => {
+  describe("GET /posts/:postid/", () => {
+    it("returns the seeded post for a known postid (no auth required)", async () => {
+      const res = await fetch("http://localhost/posts/10000/");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.postid).toBe(10000);
+      expect(typeof body.title).toBe("string");
+      expect(typeof body.text).toBe("string");
+      expect(typeof body.isAnnouncement).toBe("boolean");
+      expect(typeof body.likesCount).toBe("number");
+    });
+
+    it("returns 404 for unknown postid", async () => {
+      const res = await fetch("http://localhost/posts/999999/");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /posts/", () => {
+    it("returns 401 when Authorization header is missing", async () => {
+      const res = await fetch("http://localhost/posts/", {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(newCommunityPost()),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("creates a community post and assigns a new postid; subsequent GET returns it", async () => {
+      const res = await fetch("http://localhost/posts/", {
+        method: "POST",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify(newCommunityPost({ title: "Hello world" })),
+      });
+      expect(res.status).toBe(200);
+      const created = await res.json();
+      expect(typeof created.postid).toBe("number");
+
+      const getRes = await fetch(`http://localhost/posts/${created.postid}/`);
+      expect(getRes.status).toBe(200);
+      const got = await getRes.json();
+      expect(got.title).toBe("Hello world");
+      expect(got.email).toBe(MOCK_USER_EMAIL);
+    });
+
+    it("returns 403 when non-admin attempts announcement creation", async () => {
+      const res = await fetch("http://localhost/posts/", {
+        method: "POST",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify(newAnnouncementPayload()),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("allows admin to create an announcement", async () => {
+      sessionStorage.setItem(ADMIN_KEY, "1");
+      const res = await fetch("http://localhost/posts/", {
+        method: "POST",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify(newAnnouncementPayload()),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(typeof body.postid).toBe("number");
+    });
+  });
+
+  describe("PATCH /posts/:postid/", () => {
+    it("returns 401 without Authorization header", async () => {
+      const res = await fetch("http://localhost/posts/10000/", {
+        method: "PATCH",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ type: BoardType.Community, title: "New", text: "x", isAnnouncement: false }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("author can update their own post (title + text)", async () => {
+      // Seed: postid 10000 in fixture is authored by MOCK_USER_EMAIL.
+      const res = await fetch("http://localhost/posts/10000/", {
+        method: "PATCH",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify({
+          type: BoardType.Community,
+          title: "Updated title",
+          text: "Updated body",
+          isAnnouncement: false,
+        }),
+      });
+      expect(res.status).toBe(200);
+
+      const getRes = await fetch("http://localhost/posts/10000/");
+      const got = await getRes.json();
+      expect(got.title).toBe("Updated title");
+      expect(got.text).toBe("Updated body");
+    });
+
+    it("returns 403 when non-author non-admin tries to update", async () => {
+      // Seed: postid 10001 is authored by OTHER_USER_EMAIL in fixture.
+      const res = await fetch("http://localhost/posts/10001/", {
+        method: "PATCH",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify({
+          type: BoardType.Community,
+          title: "Hacked",
+          text: "tampered",
+          isAnnouncement: false,
+        }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("admin override: admin can update someone else's post", async () => {
+      sessionStorage.setItem(ADMIN_KEY, "1");
+      const res = await fetch("http://localhost/posts/10001/", {
+        method: "PATCH",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify({
+          type: BoardType.Community,
+          title: "Moderated",
+          text: "Moderated body",
+          isAnnouncement: false,
+        }),
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("DELETE /posts/:postid/", () => {
+    it("returns 401 without Authorization header", async () => {
+      const res = await fetch("http://localhost/posts/10000/", { method: "DELETE" });
+      expect(res.status).toBe(401);
+    });
+
+    it("author can delete their own post; subsequent GET returns 404", async () => {
+      const res = await fetch("http://localhost/posts/10000/", {
+        method: "DELETE",
+        headers: AUTH_HEADER,
+      });
+      expect(res.status).toBe(200);
+
+      const getRes = await fetch("http://localhost/posts/10000/");
+      expect(getRes.status).toBe(404);
+    });
+
+    it("returns 403 when non-author non-admin tries to delete", async () => {
+      const res = await fetch("http://localhost/posts/10001/", {
+        method: "DELETE",
+        headers: AUTH_HEADER,
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("admin override: admin can delete someone else's post", async () => {
+      sessionStorage.setItem(ADMIN_KEY, "1");
+      const res = await fetch("http://localhost/posts/10001/", {
+        method: "DELETE",
+        headers: AUTH_HEADER,
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("PATCH /posts/readCount/:postid/", () => {
+    it("increments readCount; subsequent GET reflects the increment", async () => {
+      const before = await fetch("http://localhost/posts/10000/").then((r) => r.json());
+      const startCount = before.readCount;
+
+      const res = await fetch("http://localhost/posts/readCount/10000/", { method: "PATCH" });
+      expect(res.status).toBe(200);
+
+      const after = await fetch("http://localhost/posts/10000/").then((r) => r.json());
+      expect(after.readCount).toBe(startCount + 1);
+    });
+
+    it("returns 404 for unknown postid", async () => {
+      const res = await fetch("http://localhost/posts/readCount/999999/", { method: "PATCH" });
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -4,6 +4,7 @@ import { authHandlers } from "./auth";
 import { usersHandlers } from "./users";
 import { pochaHandlers } from "./pocha";
 import { boardsHandlers } from "./boards";
+import { postsHandlers } from "./posts";
 
 /**
  * MSW request handlers.
@@ -16,4 +17,5 @@ export const handlers: RequestHandler[] = [
   ...usersHandlers,
   ...pochaHandlers,
   ...boardsHandlers,
+  ...postsHandlers,
 ];

--- a/src/mocks/handlers/posts.ts
+++ b/src/mocks/handlers/posts.ts
@@ -1,0 +1,125 @@
+import { http, HttpResponse } from "msw";
+import { BoardType } from "@/types/board";
+import type { NewPostBody, UpdatePostBody } from "@/types/post";
+import {
+  MOCK_USER_EMAIL,
+  getPostsStore,
+  nextPostId,
+  resetPostsStore,
+} from "../fixtures/posts";
+
+const ADMIN_KEY = "kisa-mock-auth-isadmin";
+
+function isAdmin(): boolean {
+  try {
+    return sessionStorage.getItem(ADMIN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function requireAuth(authHeader: string | null): boolean {
+  return Boolean(authHeader && authHeader.length > 0);
+}
+
+export const postsHandlers = [
+  http.get("*/posts/:postid/", ({ params }) => {
+    const id = Number(params.postid);
+    const store = getPostsStore();
+    const post = store.get(id);
+    if (!post) {
+      return HttpResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+    return HttpResponse.json(post);
+  }),
+
+  http.post("*/posts/", async ({ request }) => {
+    if (!requireAuth(request.headers.get("Authorization"))) {
+      return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const body = (await request.json()) as NewPostBody;
+    if (body.type === BoardType.Announcement && !isAdmin()) {
+      return HttpResponse.json(
+        { error: "Admin required for announcement creation" },
+        { status: 403 }
+      );
+    }
+    const id = nextPostId();
+    const store = getPostsStore();
+    store.set(id, {
+      postid: id,
+      title: body.title,
+      created: new Date().toISOString(),
+      type: body.type,
+      fullname: body.fullname,
+      email: body.email,
+      readCount: body.readCount ?? 0,
+      commentsCount: 0,
+      anonymous: body.anonymous,
+      likesCount: 0,
+      text: body.text,
+      isAnnouncement: body.isAnnouncement,
+    });
+    return HttpResponse.json({ postid: id, message: "Created" });
+  }),
+
+  http.patch("*/posts/readCount/:postid/", ({ params }) => {
+    const id = Number(params.postid);
+    const store = getPostsStore();
+    const post = store.get(id);
+    if (!post) {
+      return HttpResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+    store.set(id, { ...post, readCount: post.readCount + 1 });
+    return HttpResponse.json({ message: "OK" });
+  }),
+
+  http.patch("*/posts/:postid/", async ({ request, params }) => {
+    if (!requireAuth(request.headers.get("Authorization"))) {
+      return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const id = Number(params.postid);
+    const store = getPostsStore();
+    const post = store.get(id);
+    if (!post) {
+      return HttpResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+    if (post.email !== MOCK_USER_EMAIL && !isAdmin()) {
+      return HttpResponse.json(
+        { error: "Author or admin required" },
+        { status: 403 }
+      );
+    }
+    const body = (await request.json()) as UpdatePostBody;
+    store.set(id, {
+      ...post,
+      type: body.type,
+      title: body.title,
+      text: body.text,
+      isAnnouncement: body.isAnnouncement,
+    });
+    return HttpResponse.json({ message: "Updated" });
+  }),
+
+  http.delete("*/posts/:postid/", ({ request, params }) => {
+    if (!requireAuth(request.headers.get("Authorization"))) {
+      return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const id = Number(params.postid);
+    const store = getPostsStore();
+    const post = store.get(id);
+    if (!post) {
+      return HttpResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+    if (post.email !== MOCK_USER_EMAIL && !isAdmin()) {
+      return HttpResponse.json(
+        { error: "Author or admin required" },
+        { status: 403 }
+      );
+    }
+    store.delete(id);
+    return HttpResponse.json({ message: "Deleted" });
+  }),
+];
+
+export { resetPostsStore };


### PR DESCRIPTION
Closes #168

## Summary
Mocks the 5 `/posts` endpoints with full-body `Post` fixtures. Auth + permission semantics mirror the issue spec: announcement-creation is admin-only; PATCH/DELETE are author-only with admin override. `readCount` increments persist across fetches in the same handler session.

## Changes
- `src/mocks/fixtures/posts.ts` — 5 seeded full-body posts in postid range 10000–10004. id 10000 = `tester@umich.edu` (mock user; author tests); id 10001 = different email (admin-override tests). `getPostsStore` + `nextPostId` + `resetPostsStore` exposed for handlers and per-test reset.
- `src/mocks/handlers/posts.ts` — `postsHandlers` for GET, POST, PATCH `/posts/:id/`, PATCH `/posts/readCount/:id/`, DELETE. `readCount` route registered before generic `/posts/:postid/` PATCH so MSW route resolution picks the more-specific match. Admin flag read from `kisa-mock-auth-isadmin` sessionStorage key (matches `auth.ts` convention).
- `src/mocks/handlers/__tests__/posts.test.ts` — 16 cases covering: shape on GET, 404 on unknown, 401 on missing auth, admin-only announcement creation, author/admin/stranger permission matrix on PATCH + DELETE, readCount idempotent increment.
- `src/mocks/handlers/index.ts` — register `postsHandlers`.

## Verification
- `npm test` → 183 pass / 3 pre-existing skips (no regressions); 16 new posts-suite cases all pass.
- `npx tsc --noEmit` clean.

## Scope tag
`[MECHANICAL]` `[TDD]`

## Notes
- Cross-lane fixture postids: 6.5c/6.5d should reference postids 10000+ to align with this fixture.
- PATCH `/posts/:postid/` (body update) and PATCH `/posts/readCount/:postid/` are both PATCH; the readCount handler is registered first so MSW's route matcher resolves it before falling through to the generic body-update handler.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UkaBc9gyteSFHjTZgmZf4a)_