### PR TITLE
[Phase 6 / 6.5c] MECHANICAL: MSW comments CRUD handlers + fixtures

### DIFF
--- a/src/mocks/fixtures/comments.ts
+++ b/src/mocks/fixtures/comments.ts
@@ -1,0 +1,176 @@
+import type { Comment } from "@/types/comment";
+import { BoardType } from "@/types/board";
+
+export const MOCK_USER_EMAIL = "tester@umich.edu";
+
+const EVERYKISA_BOARDS: ReadonlySet<BoardType> = new Set([
+  BoardType.Community,
+  BoardType.Concern,
+  BoardType.Academic,
+  BoardType.Career,
+  BoardType.LivingQA,
+]);
+
+/**
+ * Cross-lane postid → board-type contract. Each Comment fixture postid maps
+ * to a board so the handler can apply the everykisa anonymous-flag rule.
+ * Postids 10000–10004 mirror the 6.5b posts fixture exactly.
+ */
+export const POST_BOARD_TYPE: ReadonlyMap<number, BoardType> = new Map([
+  [10000, BoardType.Community], // everykisa
+  [10001, BoardType.BuyAndSell], // non-everykisa
+  [10002, BoardType.Academic], // everykisa
+  [10003, BoardType.Announcement], // non-everykisa
+  [10004, BoardType.Housing], // non-everykisa
+]);
+
+export function isEverykisaPost(postid: number): boolean {
+  const board = POST_BOARD_TYPE.get(postid);
+  return board != null && EVERYKISA_BOARDS.has(board);
+}
+
+/**
+ * Seed comments. The community post (10000) gets a 3-level nested tree
+ * required by the lane spec; other posts get smaller fixtures so endpoint
+ * coverage is exercised across the matrix.
+ *
+ * Tester user (`MOCK_USER_EMAIL`) authors at least one comment per post so
+ * author-edit and author-delete tests can find a target.
+ */
+const _comments: Comment[] = [
+  // Post 10000 — Community (everykisa). 3-level depth.
+  {
+    commentid: 1,
+    postid: 10000,
+    email: MOCK_USER_EMAIL,
+    fullname: "KISA Tester",
+    text: "이용 방법이 안 올라왔는데요",
+    isCommentOfComment: false,
+    parentCommentid: null,
+    created: "2026-04-01T13:00:00Z",
+    anonymous: true,
+    secret: false,
+    likesCount: 3,
+    childComments: [],
+  },
+  {
+    commentid: 2,
+    postid: 10000,
+    email: "dongsubk@umich.edu",
+    fullname: "김동섭",
+    text: "착한 사람 눈에만 보입니다",
+    isCommentOfComment: true,
+    parentCommentid: 1,
+    created: "2026-04-01T13:30:00Z",
+    anonymous: false,
+    secret: false,
+    likesCount: 1,
+    childComments: [],
+  },
+  {
+    commentid: 3,
+    postid: 10000,
+    email: "ianpark@umich.edu",
+    fullname: "박이안",
+    text: "개노잼 글이네요",
+    isCommentOfComment: false,
+    parentCommentid: null,
+    created: "2026-04-01T14:00:00Z",
+    anonymous: true,
+    secret: false,
+    likesCount: 0,
+    childComments: [],
+  },
+  {
+    commentid: 4,
+    postid: 10000,
+    email: "kinn@umich.edu",
+    fullname: "인경민",
+    text: "예의 좀 지키시죠",
+    isCommentOfComment: true,
+    parentCommentid: 3,
+    created: "2026-04-01T14:15:00Z",
+    anonymous: true,
+    secret: false,
+    likesCount: 2,
+    childComments: [],
+  },
+  {
+    commentid: 5,
+    postid: 10000,
+    email: "ianpark@umich.edu",
+    fullname: "박이안",
+    text: "정숙해주세요",
+    isCommentOfComment: true,
+    parentCommentid: 4,
+    created: "2026-04-01T14:30:00Z",
+    anonymous: false,
+    secret: false,
+    likesCount: 0,
+    childComments: [],
+  },
+
+  // Post 10001 — BuyAndSell (non-everykisa). Tester comment for author tests.
+  {
+    commentid: 6,
+    postid: 10001,
+    email: MOCK_USER_EMAIL,
+    fullname: "KISA Tester",
+    text: "혹시 가격 협의 가능할까요?",
+    isCommentOfComment: false,
+    parentCommentid: null,
+    created: "2026-04-02T16:00:00Z",
+    anonymous: false,
+    secret: false,
+    likesCount: 0,
+    childComments: [],
+  },
+  {
+    commentid: 7,
+    postid: 10001,
+    email: "seoyeonp@umich.edu",
+    fullname: "박서연",
+    text: "DM 보내드렸습니다",
+    isCommentOfComment: true,
+    parentCommentid: 6,
+    created: "2026-04-02T17:00:00Z",
+    anonymous: false,
+    secret: false,
+    likesCount: 1,
+    childComments: [],
+  },
+
+  // Post 10002 — Academic (everykisa).
+  {
+    commentid: 8,
+    postid: 10002,
+    email: MOCK_USER_EMAIL,
+    fullname: "KISA Tester",
+    text: "저도 똑같이 느꼈어요",
+    isCommentOfComment: false,
+    parentCommentid: null,
+    created: "2026-04-05T10:00:00Z",
+    anonymous: true,
+    secret: false,
+    likesCount: 5,
+    childComments: [],
+  },
+];
+
+export type CommentsStore = Map<number, Comment>;
+
+let store: CommentsStore = new Map(_comments.map((c) => [c.commentid, c]));
+let nextId = 10000;
+
+export function getCommentsStore(): CommentsStore {
+  return store;
+}
+
+export function nextCommentId(): number {
+  return nextId++;
+}
+
+export function resetCommentsStore(): void {
+  store = new Map(_comments.map((c) => [c.commentid, { ...c, childComments: [] }]));
+  nextId = 10000;
+}

--- a/src/mocks/handlers/__tests__/comments.test.ts
+++ b/src/mocks/handlers/__tests__/comments.test.ts
@@ -1,0 +1,261 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { setupServer } from "msw/node";
+import { commentsHandlers, resetCommentsStore } from "../comments";
+import type { Comment } from "@/types/comment";
+
+const server = setupServer(...commentsHandlers);
+
+const ADMIN_KEY = "kisa-mock-auth-isadmin";
+const AUTH_HEADER = { Authorization: "Bearer mock-access-token" };
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+const MOCK_USER_EMAIL = "tester@umich.edu";
+
+// 6.5b cross-lane contract: postid 10000 (Community → everykisa), 10001 (BuyAndSell → board), 10002 (Academic → everykisa).
+const COMMUNITY_POSTID = 10000; // everykisa
+const BUYANDSELL_POSTID = 10001; // non-everykisa
+
+const newComment = (overrides?: Partial<Record<string, unknown>>) => ({
+  email: MOCK_USER_EMAIL,
+  fullname: "KISA Tester",
+  text: "Hello",
+  isCommentOfComment: false,
+  parentCommentid: null,
+  anonymous: false,
+  secret: false,
+  ...overrides,
+});
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+beforeEach(() => sessionStorage.removeItem(ADMIN_KEY));
+afterEach(() => {
+  server.resetHandlers();
+  resetCommentsStore();
+  sessionStorage.removeItem(ADMIN_KEY);
+});
+afterAll(() => server.close());
+
+function maxDepth(comments: Comment[]): number {
+  if (comments.length === 0) return 0;
+  return 1 + Math.max(...comments.map((c) => maxDepth(c.childComments ?? [])));
+}
+
+describe("MSW comments handlers", () => {
+  describe("GET /comments/:postid/", () => {
+    it("returns nested tree with childComments populated; depth >= 3 on community fixture", async () => {
+      const res = await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`);
+      expect(res.status).toBe(200);
+      const tree = (await res.json()) as Comment[];
+      expect(Array.isArray(tree)).toBe(true);
+      expect(tree.length).toBeGreaterThan(0);
+      expect(maxDepth(tree)).toBeGreaterThanOrEqual(3);
+      for (const root of tree) {
+        expect(root.parentCommentid).toBeNull();
+        expect(Array.isArray(root.childComments)).toBe(true);
+      }
+    });
+
+    it("returns [] for postid with no comments", async () => {
+      const res = await fetch("http://localhost/comments/999999/");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual([]);
+    });
+  });
+
+  describe("POST /comments/:postid/", () => {
+    it("returns 401 without Authorization header", async () => {
+      const res = await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`, {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(newComment()),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("creates a top-level comment; subsequent GET shows it as a new root", async () => {
+      const res = await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`, {
+        method: "POST",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify(newComment({ text: "Brand new comment" })),
+      });
+      expect(res.status).toBe(200);
+
+      const tree = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      expect(tree.some((c) => c.text === "Brand new comment")).toBe(true);
+    });
+
+    it("creates a child comment under an existing parent (childComments populated)", async () => {
+      const tree0 = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const parentId = tree0[0].commentid;
+
+      const res = await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`, {
+        method: "POST",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify(
+          newComment({
+            text: "child reply",
+            isCommentOfComment: true,
+            parentCommentid: parentId,
+          })
+        ),
+      });
+      expect(res.status).toBe(200);
+
+      const tree1 = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const parent = tree1.find((c) => c.commentid === parentId)!;
+      const childTexts = parent.childComments.map((c) => c.text);
+      expect(childTexts).toContain("child reply");
+    });
+
+    it("everykisa post: anonymous: true is honored as-is", async () => {
+      const res = await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`, {
+        method: "POST",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify(newComment({ text: "anon comment", anonymous: true })),
+      });
+      expect(res.status).toBe(200);
+
+      const tree = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const created = tree.find((c) => c.text === "anon comment");
+      expect(created).toBeDefined();
+      expect(created!.anonymous).toBe(true);
+    });
+
+    it("non-everykisa post: anonymous: true is normalized to false", async () => {
+      const res = await fetch(`http://localhost/comments/${BUYANDSELL_POSTID}/`, {
+        method: "POST",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify(newComment({ text: "should-not-be-anon", anonymous: true })),
+      });
+      expect(res.status).toBe(200);
+
+      const tree = (await fetch(`http://localhost/comments/${BUYANDSELL_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const created = tree.find((c) => c.text === "should-not-be-anon");
+      expect(created).toBeDefined();
+      expect(created!.anonymous).toBe(false);
+    });
+  });
+
+  describe("PUT /comments/:commentid/", () => {
+    it("returns 401 without Authorization", async () => {
+      const tree = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const cid = tree[0].commentid;
+      const res = await fetch(`http://localhost/comments/${cid}/`, {
+        method: "PUT",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ text: "x" }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("author can edit their own comment", async () => {
+      // Seed: in the community fixture, find a comment authored by MOCK_USER_EMAIL.
+      const tree = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const myComment = tree.find((c) => c.email === MOCK_USER_EMAIL)!;
+      expect(myComment).toBeDefined();
+
+      const res = await fetch(`http://localhost/comments/${myComment.commentid}/`, {
+        method: "PUT",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify({ text: "edited body" }),
+      });
+      expect(res.status).toBe(200);
+
+      const tree2 = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const updated = tree2.find((c) => c.commentid === myComment.commentid)!;
+      expect(updated.text).toBe("edited body");
+    });
+
+    it("returns 403 when non-author non-admin tries to edit", async () => {
+      const tree = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const otherComment = tree.find((c) => c.email !== MOCK_USER_EMAIL)!;
+      const res = await fetch(`http://localhost/comments/${otherComment.commentid}/`, {
+        method: "PUT",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify({ text: "hacked" }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("admin override: admin can edit anyone's comment", async () => {
+      sessionStorage.setItem(ADMIN_KEY, "1");
+      const tree = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const otherComment = tree.find((c) => c.email !== MOCK_USER_EMAIL)!;
+      const res = await fetch(`http://localhost/comments/${otherComment.commentid}/`, {
+        method: "PUT",
+        headers: { ...AUTH_HEADER, ...JSON_HEADERS },
+        body: JSON.stringify({ text: "moderated" }),
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("DELETE /comments/:commentid/", () => {
+    it("returns 401 without Authorization", async () => {
+      const tree = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const cid = tree[0].commentid;
+      const res = await fetch(`http://localhost/comments/${cid}/`, { method: "DELETE" });
+      expect(res.status).toBe(401);
+    });
+
+    it("author can delete their own comment; subsequent GET no longer includes it", async () => {
+      const tree = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const myComment = tree.find((c) => c.email === MOCK_USER_EMAIL)!;
+      const res = await fetch(`http://localhost/comments/${myComment.commentid}/`, {
+        method: "DELETE",
+        headers: AUTH_HEADER,
+      });
+      expect(res.status).toBe(204);
+
+      const tree2 = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      function findById(arr: Comment[], id: number): Comment | undefined {
+        for (const c of arr) {
+          if (c.commentid === id) return c;
+          const inChild = findById(c.childComments ?? [], id);
+          if (inChild) return inChild;
+        }
+        return undefined;
+      }
+      expect(findById(tree2, myComment.commentid)).toBeUndefined();
+    });
+
+    it("returns 403 when non-author non-admin tries to delete", async () => {
+      const tree = (await fetch(`http://localhost/comments/${COMMUNITY_POSTID}/`).then((r) =>
+        r.json()
+      )) as Comment[];
+      const otherComment = tree.find((c) => c.email !== MOCK_USER_EMAIL)!;
+      const res = await fetch(`http://localhost/comments/${otherComment.commentid}/`, {
+        method: "DELETE",
+        headers: AUTH_HEADER,
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/src/mocks/handlers/comments.ts
+++ b/src/mocks/handlers/comments.ts
@@ -1,0 +1,129 @@
+import { http, HttpResponse } from "msw";
+import type { Comment, NewCommentBody, UpdateCommentBody } from "@/types/comment";
+import {
+  MOCK_USER_EMAIL,
+  getCommentsStore,
+  isEverykisaPost,
+  nextCommentId,
+  resetCommentsStore,
+} from "../fixtures/comments";
+
+const ADMIN_KEY = "kisa-mock-auth-isadmin";
+
+function isAdmin(): boolean {
+  try {
+    return sessionStorage.getItem(ADMIN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function requireAuth(authHeader: string | null): boolean {
+  return Boolean(authHeader && authHeader.length > 0);
+}
+
+/**
+ * Build a nested tree from the flat store for the given postid.
+ * Each parent's `childComments` is populated recursively.
+ */
+function buildTreeForPost(postid: number): Comment[] {
+  const flat = Array.from(getCommentsStore().values()).filter(
+    (c) => c.postid === postid
+  );
+  const byId = new Map<number, Comment>();
+  // Reset childComments to empty arrays so we don't leak previous tree state.
+  for (const c of flat) {
+    byId.set(c.commentid, { ...c, childComments: [] });
+  }
+  const roots: Comment[] = [];
+  for (const c of byId.values()) {
+    if (c.parentCommentid == null) {
+      roots.push(c);
+    } else {
+      const parent = byId.get(c.parentCommentid);
+      if (parent) {
+        parent.childComments.push(c);
+      } else {
+        // Orphaned child (parent deleted) — surface as a root so it isn't lost.
+        roots.push(c);
+      }
+    }
+  }
+  return roots;
+}
+
+export const commentsHandlers = [
+  http.get("*/comments/:postid/", ({ params }) => {
+    const postid = Number(params.postid);
+    return HttpResponse.json(buildTreeForPost(postid));
+  }),
+
+  http.post("*/comments/:postid/", async ({ request, params }) => {
+    if (!requireAuth(request.headers.get("Authorization"))) {
+      return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const postid = Number(params.postid);
+    const body = (await request.json()) as NewCommentBody;
+    const id = nextCommentId();
+    const anonymous = isEverykisaPost(postid) ? body.anonymous : false;
+    const created: Comment = {
+      commentid: id,
+      postid,
+      email: body.email,
+      fullname: body.fullname,
+      text: body.text,
+      isCommentOfComment: body.isCommentOfComment,
+      parentCommentid: body.parentCommentid,
+      anonymous,
+      secret: body.secret,
+      created: new Date().toISOString(),
+      likesCount: 0,
+      childComments: [],
+    };
+    getCommentsStore().set(id, created);
+    return HttpResponse.json({ commentid: id, message: "Comment posted successfully" });
+  }),
+
+  http.put("*/comments/:commentid/", async ({ request, params }) => {
+    if (!requireAuth(request.headers.get("Authorization"))) {
+      return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const id = Number(params.commentid);
+    const store = getCommentsStore();
+    const existing = store.get(id);
+    if (!existing) {
+      return HttpResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    if (existing.email !== MOCK_USER_EMAIL && !isAdmin()) {
+      return HttpResponse.json(
+        { error: "Author or admin required" },
+        { status: 403 }
+      );
+    }
+    const body = (await request.json()) as UpdateCommentBody;
+    store.set(id, { ...existing, text: body.text });
+    return HttpResponse.json({ commentid: id, text: body.text });
+  }),
+
+  http.delete("*/comments/:commentid/", ({ request, params }) => {
+    if (!requireAuth(request.headers.get("Authorization"))) {
+      return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const id = Number(params.commentid);
+    const store = getCommentsStore();
+    const existing = store.get(id);
+    if (!existing) {
+      return HttpResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    if (existing.email !== MOCK_USER_EMAIL && !isAdmin()) {
+      return HttpResponse.json(
+        { error: "Author or admin required" },
+        { status: 403 }
+      );
+    }
+    store.delete(id);
+    return new HttpResponse(null, { status: 204 });
+  }),
+];
+
+export { resetCommentsStore };

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -5,6 +5,7 @@ import { usersHandlers } from "./users";
 import { pochaHandlers } from "./pocha";
 import { boardsHandlers } from "./boards";
 import { postsHandlers } from "./posts";
+import { commentsHandlers } from "./comments";
 
 /**
  * MSW request handlers.
@@ -18,4 +19,5 @@ export const handlers: RequestHandler[] = [
   ...pochaHandlers,
   ...boardsHandlers,
   ...postsHandlers,
+  ...commentsHandlers,
 ];


### PR DESCRIPTION
Closes #169

## Summary
Mocks 4 `/comments` endpoints with nested-tree GET, anon-flag normalization, and author/admin permission gating. Fixture seeds a 3-level deep tree on community post 10000 to exercise the recursive `childComments` rendering path.

## Changes
- `src/mocks/fixtures/comments.ts` — 8 seeded comments across postids 10000–10002. `POST_BOARD_TYPE` map associates each fixture postid with its `BoardType` so the handler can apply the everykisa anonymous-flag rule. `MOCK_USER_EMAIL` authors at least one comment per post → author-edit/author-delete tests can find a target.
- `src/mocks/handlers/comments.ts` — `commentsHandlers` for GET, POST, PUT, DELETE. `buildTreeForPost` rebuilds the nested tree on every GET (childComments are derived, not stored, so updates/inserts don't drift). Anon-flag normalization in POST: `isEverykisaPost(postid)` decides whether to honor or coerce `anonymous`. DELETE returns 204 per `mutations.ts` JSDoc contract.
- `src/mocks/handlers/__tests__/comments.test.ts` — 14 cases: nested-tree depth assertion, empty-postid GET, 401/403 matrix on POST/PUT/DELETE, anon-flag honor vs normalize, author/admin/stranger permission matrix on edit + delete, child comment insertion under existing parent.
- `src/mocks/handlers/index.ts` — register `commentsHandlers`.

## Verification
- `npm test` → 181 pass / 3 pre-existing skips (no regressions); 14 new comments-suite cases all pass.
- `npx tsc --noEmit` clean.

## Scope tag
`[MECHANICAL]` `[TDD]`

## Notes
- Cross-lane: postids 10000–10004 align with 6.5b's posts fixture; `POST_BOARD_TYPE` is the source of truth for everykisa membership in this lane (mirror in 6.5d if it needs the rule too).
- Comment tree depth is unbounded — the handler simply walks `parentCommentid` references in the flat store.
- Orphaned children (parent deleted) surface as new roots so they aren't silently dropped from the tree.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UkaBc9gyteSFHjTZgmZf4a)_