### PR TITLE
[Phase 6 / 6.5d] MECHANICAL: MSW likes handlers + fixtures

### DIFF
--- a/src/mocks/fixtures/likes.ts
+++ b/src/mocks/fixtures/likes.ts
@@ -1,0 +1,38 @@
+/**
+ * Likes fixtures — seed data for MSW likes handlers.
+ *
+ * Cross-lane invariant (per phase-6 plan.md Lane 6.5d):
+ *   - postids referenced here must exist in 6.5b's posts fixture (range 10000-10004).
+ *   - commentids referenced here must exist in 6.5c's comments fixture (range 1-8).
+ *
+ * A like is keyed by the (target, id, email) tuple. The handler stores them
+ * as a flat array so toggling, count derivation, and per-user lookup are all
+ * trivial scans.
+ */
+
+export type LikeTarget = "post" | "comment";
+
+export interface LikeRecord {
+  id: number;
+  email: string;
+  target: LikeTarget;
+}
+
+export const MOCK_USER_EMAIL = "tester@umich.edu";
+
+const SEED_LIKES: LikeRecord[] = [
+  // Post 10000: liked by tester + one other user (count=2 baseline).
+  { id: 10000, email: MOCK_USER_EMAIL, target: "post" },
+  { id: 10000, email: "alice@umich.edu", target: "post" },
+  // Post 10002: liked by one other user only.
+  { id: 10002, email: "bob@umich.edu", target: "post" },
+  // Comment 1: liked by tester + one other (count=2 baseline).
+  { id: 1, email: MOCK_USER_EMAIL, target: "comment" },
+  { id: 1, email: "alice@umich.edu", target: "comment" },
+  // Comment 3: liked by one other user only.
+  { id: 3, email: "bob@umich.edu", target: "comment" },
+];
+
+export function getSeedLikes(): LikeRecord[] {
+  return SEED_LIKES.map((l) => ({ ...l }));
+}

--- a/src/mocks/handlers/__tests__/likes.test.ts
+++ b/src/mocks/handlers/__tests__/likes.test.ts
@@ -1,0 +1,390 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { setupServer } from "msw/node";
+import { likesHandlers, resetLikesStore } from "../likes";
+
+const server = setupServer(...likesHandlers);
+
+const AUTH = { Authorization: "Bearer mock-access-token" };
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => {
+  server.resetHandlers();
+  resetLikesStore();
+});
+afterAll(() => server.close());
+
+const SEED_LIKED_POSTID = 10000;
+const SEED_UNLIKED_POSTID = 10001;
+const SEED_LIKED_COMMENTID = 1;
+const SEED_UNLIKED_COMMENTID = 2;
+const SEED_USER = "tester@umich.edu";
+const OTHER_USER = "other@umich.edu";
+
+const url = (
+  base: string,
+  qs?: Record<string, string>
+) => {
+  const u = new URL(`http://localhost${base}`);
+  if (qs) Object.entries(qs).forEach(([k, v]) => u.searchParams.set(k, v));
+  return u.toString();
+};
+
+describe("MSW likes handlers", () => {
+  describe("GET /likes/:id/ — has-user-liked check", () => {
+    it("returns truthy data when the user has liked the target post", async () => {
+      const res = await fetch(
+        url(`/likes/${SEED_LIKED_POSTID}/`, {
+          email: SEED_USER,
+          target: "post",
+        }),
+        { headers: AUTH }
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toBeTruthy();
+      expect(body.email).toBe(SEED_USER);
+      expect(body.target).toBe("post");
+    });
+
+    it("returns 404 when the user has not liked the target post", async () => {
+      const res = await fetch(
+        url(`/likes/${SEED_UNLIKED_POSTID}/`, {
+          email: SEED_USER,
+          target: "post",
+        }),
+        { headers: AUTH }
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("returns truthy data when the user has liked the target comment", async () => {
+      const res = await fetch(
+        url(`/likes/${SEED_LIKED_COMMENTID}/`, {
+          email: SEED_USER,
+          target: "comment",
+        }),
+        { headers: AUTH }
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.target).toBe("comment");
+    });
+
+    it("returns 404 when the user has not liked the target comment", async () => {
+      const res = await fetch(
+        url(`/likes/${SEED_UNLIKED_COMMENTID}/`, {
+          email: SEED_USER,
+          target: "comment",
+        }),
+        { headers: AUTH }
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("discriminates targets — post-like on id N is not the same as comment-like on id N", async () => {
+      // Seed has a post-like on 10000, but no comment-like on 10000.
+      const res = await fetch(
+        url(`/likes/${SEED_LIKED_POSTID}/`, {
+          email: SEED_USER,
+          target: "comment",
+        }),
+        { headers: AUTH }
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 401 when Authorization header is missing", async () => {
+      const res = await fetch(
+        url(`/likes/${SEED_LIKED_POSTID}/`, {
+          email: SEED_USER,
+          target: "post",
+        })
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("GET /posts/likes/:postid/ — count", () => {
+    it("returns { likesCount } for a post", async () => {
+      const res = await fetch(`http://localhost/posts/likes/${SEED_LIKED_POSTID}/`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(typeof body.likesCount).toBe("number");
+      expect(body.likesCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it("returns { likesCount: 0 } for a post with no likes", async () => {
+      const res = await fetch(`http://localhost/posts/likes/${SEED_UNLIKED_POSTID}/`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.likesCount).toBe(0);
+    });
+
+    it("does not require auth for the count endpoint", async () => {
+      const res = await fetch(`http://localhost/posts/likes/${SEED_LIKED_POSTID}/`);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("GET /comments/likes/:commentid/ — count", () => {
+    it("returns { likesCount } for a comment", async () => {
+      const res = await fetch(
+        `http://localhost/comments/likes/${SEED_LIKED_COMMENTID}/`
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(typeof body.likesCount).toBe("number");
+      expect(body.likesCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it("returns { likesCount: 0 } for a comment with no likes", async () => {
+      const res = await fetch(
+        `http://localhost/comments/likes/${SEED_UNLIKED_COMMENTID}/`
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.likesCount).toBe(0);
+    });
+  });
+
+  describe("POST /likes/:id/ — create like", () => {
+    it("adds a post like; subsequent GET reflects it; count increments", async () => {
+      // Baseline count
+      const before = await fetch(
+        `http://localhost/posts/likes/${SEED_UNLIKED_POSTID}/`
+      ).then((r) => r.json());
+      expect(before.likesCount).toBe(0);
+
+      const create = await fetch(`http://localhost/likes/${SEED_UNLIKED_POSTID}/`, {
+        method: "POST",
+        headers: { ...AUTH, "Content-Type": "application/json" },
+        body: JSON.stringify({ email: SEED_USER, target: "post" }),
+      });
+      expect(create.status).toBe(201);
+
+      const after = await fetch(
+        `http://localhost/posts/likes/${SEED_UNLIKED_POSTID}/`
+      ).then((r) => r.json());
+      expect(after.likesCount).toBe(1);
+
+      const lookup = await fetch(
+        url(`/likes/${SEED_UNLIKED_POSTID}/`, {
+          email: SEED_USER,
+          target: "post",
+        }),
+        { headers: AUTH }
+      );
+      expect(lookup.status).toBe(200);
+    });
+
+    it("adds a comment like and routes to the comment count, not the post count", async () => {
+      const create = await fetch(
+        `http://localhost/likes/${SEED_UNLIKED_COMMENTID}/`,
+        {
+          method: "POST",
+          headers: { ...AUTH, "Content-Type": "application/json" },
+          body: JSON.stringify({ email: SEED_USER, target: "comment" }),
+        }
+      );
+      expect(create.status).toBe(201);
+
+      const commentCount = await fetch(
+        `http://localhost/comments/likes/${SEED_UNLIKED_COMMENTID}/`
+      ).then((r) => r.json());
+      expect(commentCount.likesCount).toBe(1);
+
+      // The post-likes endpoint for the same numeric id must NOT have been
+      // incremented (target discriminator is honored).
+      const postCount = await fetch(
+        `http://localhost/posts/likes/${SEED_UNLIKED_COMMENTID}/`
+      ).then((r) => r.json());
+      expect(postCount.likesCount).toBe(0);
+    });
+
+    it("is idempotent — POSTing twice from the same user does not double the count", async () => {
+      const body = JSON.stringify({ email: SEED_USER, target: "post" });
+      const headers = { ...AUTH, "Content-Type": "application/json" };
+      await fetch(`http://localhost/likes/${SEED_UNLIKED_POSTID}/`, {
+        method: "POST",
+        headers,
+        body,
+      });
+      await fetch(`http://localhost/likes/${SEED_UNLIKED_POSTID}/`, {
+        method: "POST",
+        headers,
+        body,
+      });
+      const count = await fetch(
+        `http://localhost/posts/likes/${SEED_UNLIKED_POSTID}/`
+      ).then((r) => r.json());
+      expect(count.likesCount).toBe(1);
+    });
+
+    it("returns 401 when Authorization header is missing", async () => {
+      const res = await fetch(`http://localhost/likes/${SEED_UNLIKED_POSTID}/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: SEED_USER, target: "post" }),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("DELETE /likes/:id/ — remove like", () => {
+    it("removes the like; count decrements", async () => {
+      const before = await fetch(
+        `http://localhost/posts/likes/${SEED_LIKED_POSTID}/`
+      ).then((r) => r.json());
+      expect(before.likesCount).toBeGreaterThanOrEqual(1);
+
+      const del = await fetch(
+        url(`/likes/${SEED_LIKED_POSTID}/`, {
+          email: SEED_USER,
+          target: "post",
+        }),
+        { method: "DELETE", headers: AUTH }
+      );
+      expect([200, 204]).toContain(del.status);
+
+      const after = await fetch(
+        `http://localhost/posts/likes/${SEED_LIKED_POSTID}/`
+      ).then((r) => r.json());
+      expect(after.likesCount).toBe(before.likesCount - 1);
+
+      const lookup = await fetch(
+        url(`/likes/${SEED_LIKED_POSTID}/`, {
+          email: SEED_USER,
+          target: "post",
+        }),
+        { headers: AUTH }
+      );
+      expect(lookup.status).toBe(404);
+    });
+
+    it("returns 401 when Authorization header is missing", async () => {
+      const res = await fetch(
+        url(`/likes/${SEED_LIKED_POSTID}/`, {
+          email: SEED_USER,
+          target: "post",
+        }),
+        { method: "DELETE" }
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("does not affect another user's like for the same target", async () => {
+      // Seed has SEED_USER liking SEED_LIKED_POSTID. Add OTHER_USER too.
+      await fetch(`http://localhost/likes/${SEED_LIKED_POSTID}/`, {
+        method: "POST",
+        headers: { ...AUTH, "Content-Type": "application/json" },
+        body: JSON.stringify({ email: OTHER_USER, target: "post" }),
+      });
+      const beforeCount = await fetch(
+        `http://localhost/posts/likes/${SEED_LIKED_POSTID}/`
+      ).then((r) => r.json());
+
+      // SEED_USER unlikes; OTHER_USER's like must remain.
+      await fetch(
+        url(`/likes/${SEED_LIKED_POSTID}/`, {
+          email: SEED_USER,
+          target: "post",
+        }),
+        { method: "DELETE", headers: AUTH }
+      );
+
+      const afterCount = await fetch(
+        `http://localhost/posts/likes/${SEED_LIKED_POSTID}/`
+      ).then((r) => r.json());
+      expect(afterCount.likesCount).toBe(beforeCount.likesCount - 1);
+
+      const otherLookup = await fetch(
+        url(`/likes/${SEED_LIKED_POSTID}/`, {
+          email: OTHER_USER,
+          target: "post",
+        }),
+        { headers: AUTH }
+      );
+      expect(otherLookup.status).toBe(200);
+    });
+  });
+
+  describe("toggle invariant", () => {
+    it("POST then DELETE returns the count to its pre-toggle value", async () => {
+      const before = await fetch(
+        `http://localhost/posts/likes/${SEED_UNLIKED_POSTID}/`
+      ).then((r) => r.json());
+
+      await fetch(`http://localhost/likes/${SEED_UNLIKED_POSTID}/`, {
+        method: "POST",
+        headers: { ...AUTH, "Content-Type": "application/json" },
+        body: JSON.stringify({ email: SEED_USER, target: "post" }),
+      });
+      await fetch(
+        url(`/likes/${SEED_UNLIKED_POSTID}/`, {
+          email: SEED_USER,
+          target: "post",
+        }),
+        { method: "DELETE", headers: AUTH }
+      );
+
+      const after = await fetch(
+        `http://localhost/posts/likes/${SEED_UNLIKED_POSTID}/`
+      ).then((r) => r.json());
+      expect(after.likesCount).toBe(before.likesCount);
+    });
+
+    it("DELETE then POST returns the count to its pre-toggle value", async () => {
+      const before = await fetch(
+        `http://localhost/posts/likes/${SEED_LIKED_POSTID}/`
+      ).then((r) => r.json());
+
+      await fetch(
+        url(`/likes/${SEED_LIKED_POSTID}/`, {
+          email: SEED_USER,
+          target: "post",
+        }),
+        { method: "DELETE", headers: AUTH }
+      );
+      await fetch(`http://localhost/likes/${SEED_LIKED_POSTID}/`, {
+        method: "POST",
+        headers: { ...AUTH, "Content-Type": "application/json" },
+        body: JSON.stringify({ email: SEED_USER, target: "post" }),
+      });
+
+      const after = await fetch(
+        `http://localhost/posts/likes/${SEED_LIKED_POSTID}/`
+      ).then((r) => r.json());
+      expect(after.likesCount).toBe(before.likesCount);
+    });
+  });
+
+  describe("store reset between tests", () => {
+    it("resetLikesStore restores seed state", async () => {
+      // Mutate
+      await fetch(`http://localhost/likes/${SEED_UNLIKED_POSTID}/`, {
+        method: "POST",
+        headers: { ...AUTH, "Content-Type": "application/json" },
+        body: JSON.stringify({ email: SEED_USER, target: "post" }),
+      });
+      const mutated = await fetch(
+        `http://localhost/posts/likes/${SEED_UNLIKED_POSTID}/`
+      ).then((r) => r.json());
+      expect(mutated.likesCount).toBe(1);
+
+      resetLikesStore();
+
+      const restored = await fetch(
+        `http://localhost/posts/likes/${SEED_UNLIKED_POSTID}/`
+      ).then((r) => r.json());
+      expect(restored.likesCount).toBe(0);
+    });
+  });
+});

--- a/src/mocks/handlers/__tests__/likes.test.ts
+++ b/src/mocks/handlers/__tests__/likes.test.ts
@@ -39,7 +39,7 @@ const url = (
 
 describe("MSW likes handlers", () => {
   describe("GET /likes/:id/ — has-user-liked check", () => {
-    it("returns truthy data when the user has liked the target post", async () => {
+    it("returns { liked: true } when the user has liked the target post", async () => {
       const res = await fetch(
         url(`/likes/${SEED_LIKED_POSTID}/`, {
           email: SEED_USER,
@@ -49,12 +49,10 @@ describe("MSW likes handlers", () => {
       );
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body).toBeTruthy();
-      expect(body.email).toBe(SEED_USER);
-      expect(body.target).toBe("post");
+      expect(body.liked).toBe(true);
     });
 
-    it("returns 404 when the user has not liked the target post", async () => {
+    it("returns { liked: false } when the user has not liked the target post", async () => {
       const res = await fetch(
         url(`/likes/${SEED_UNLIKED_POSTID}/`, {
           email: SEED_USER,
@@ -62,10 +60,12 @@ describe("MSW likes handlers", () => {
         }),
         { headers: AUTH }
       );
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.liked).toBe(false);
     });
 
-    it("returns truthy data when the user has liked the target comment", async () => {
+    it("returns { liked: true } when the user has liked the target comment", async () => {
       const res = await fetch(
         url(`/likes/${SEED_LIKED_COMMENTID}/`, {
           email: SEED_USER,
@@ -75,10 +75,10 @@ describe("MSW likes handlers", () => {
       );
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body.target).toBe("comment");
+      expect(body.liked).toBe(true);
     });
 
-    it("returns 404 when the user has not liked the target comment", async () => {
+    it("returns { liked: false } when the user has not liked the target comment", async () => {
       const res = await fetch(
         url(`/likes/${SEED_UNLIKED_COMMENTID}/`, {
           email: SEED_USER,
@@ -86,7 +86,9 @@ describe("MSW likes handlers", () => {
         }),
         { headers: AUTH }
       );
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.liked).toBe(false);
     });
 
     it("discriminates targets — post-like on id N is not the same as comment-like on id N", async () => {
@@ -98,7 +100,9 @@ describe("MSW likes handlers", () => {
         }),
         { headers: AUTH }
       );
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.liked).toBe(false);
     });
 
     it("returns 401 when Authorization header is missing", async () => {
@@ -183,6 +187,7 @@ describe("MSW likes handlers", () => {
         { headers: AUTH }
       );
       expect(lookup.status).toBe(200);
+      expect((await lookup.json()).liked).toBe(true);
     });
 
     it("adds a comment like and routes to the comment count, not the post count", async () => {
@@ -266,7 +271,8 @@ describe("MSW likes handlers", () => {
         }),
         { headers: AUTH }
       );
-      expect(lookup.status).toBe(404);
+      expect(lookup.status).toBe(200);
+      expect((await lookup.json()).liked).toBe(false);
     });
 
     it("returns 401 when Authorization header is missing", async () => {
@@ -313,6 +319,7 @@ describe("MSW likes handlers", () => {
         { headers: AUTH }
       );
       expect(otherLookup.status).toBe(200);
+      expect((await otherLookup.json()).liked).toBe(true);
     });
   });
 

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -6,6 +6,7 @@ import { pochaHandlers } from "./pocha";
 import { boardsHandlers } from "./boards";
 import { postsHandlers } from "./posts";
 import { commentsHandlers } from "./comments";
+import { likesHandlers } from "./likes";
 
 /**
  * MSW request handlers.
@@ -20,4 +21,5 @@ export const handlers: RequestHandler[] = [
   ...boardsHandlers,
   ...postsHandlers,
   ...commentsHandlers,
+  ...likesHandlers,
 ];

--- a/src/mocks/handlers/likes.ts
+++ b/src/mocks/handlers/likes.ts
@@ -1,0 +1,127 @@
+import { http, HttpResponse } from "msw";
+import {
+  getSeedLikes,
+  type LikeRecord,
+  type LikeTarget,
+} from "../fixtures/likes";
+
+let likesStore: LikeRecord[] = getSeedLikes();
+
+export function resetLikesStore(): void {
+  likesStore = getSeedLikes();
+}
+
+function isTarget(value: string | null): value is LikeTarget {
+  return value === "post" || value === "comment";
+}
+
+function findLike(
+  id: number,
+  email: string,
+  target: LikeTarget
+): LikeRecord | undefined {
+  return likesStore.find(
+    (l) => l.id === id && l.target === target && l.email === email
+  );
+}
+
+function countLikes(id: number, target: LikeTarget): number {
+  return likesStore.reduce(
+    (n, l) => (l.id === id && l.target === target ? n + 1 : n),
+    0
+  );
+}
+
+function unauthorized() {
+  return HttpResponse.json({ error: "Decode failed" }, { status: 401 });
+}
+
+export const likesHandlers = [
+  // Specific count routes are registered before the wildcard /likes/:id/
+  // GET handler — the wildcard would otherwise swallow /posts/likes/{id} and
+  // /comments/likes/{id} because MSW matches the first registered handler.
+  http.get("*/posts/likes/:postid/", ({ params }) => {
+    const postid = Number(params.postid);
+    return HttpResponse.json({ likesCount: countLikes(postid, "post") });
+  }),
+
+  http.get("*/comments/likes/:commentid/", ({ params }) => {
+    const commentid = Number(params.commentid);
+    return HttpResponse.json({ likesCount: countLikes(commentid, "comment") });
+  }),
+
+  /**
+   * GET /likes/:id/?email&target — has the user liked this target?
+   * 200 with the like record when found; 404 when not.
+   * `getLikeByUser` ignores the body on errors and treats undefined as "not
+   * liked", so a 404 surfaces as a clean falsy in calling code.
+   */
+  http.get("*/likes/:id/", ({ request, params }) => {
+    if (!request.headers.get("Authorization")) return unauthorized();
+
+    const url = new URL(request.url);
+    const email = url.searchParams.get("email");
+    const target = url.searchParams.get("target");
+    if (!email || !isTarget(target)) {
+      return HttpResponse.json(
+        { error: "missing email or target" },
+        { status: 400 }
+      );
+    }
+
+    const id = Number(params.id);
+    const record = findLike(id, email, target);
+    if (!record) {
+      return HttpResponse.json({ error: "not found" }, { status: 404 });
+    }
+    return HttpResponse.json(record);
+  }),
+
+  /**
+   * POST /likes/:id/ — body { email, target }. Idempotent: a duplicate from
+   * the same (id, target, email) tuple is a no-op so optimistic-UI double-fire
+   * doesn't inflate the count.
+   */
+  http.post("*/likes/:id/", async ({ request, params }) => {
+    if (!request.headers.get("Authorization")) return unauthorized();
+
+    const id = Number(params.id);
+    const body = (await request.json()) as { email?: string; target?: string };
+    if (!body?.email || !isTarget(body.target ?? null)) {
+      return HttpResponse.json(
+        { error: "missing email or target" },
+        { status: 400 }
+      );
+    }
+    const target = body.target as LikeTarget;
+
+    const existing = findLike(id, body.email, target);
+    if (existing) {
+      return HttpResponse.json(existing, { status: 201 });
+    }
+    const created: LikeRecord = { id, email: body.email, target };
+    likesStore.push(created);
+    return HttpResponse.json(created, { status: 201 });
+  }),
+
+  http.delete("*/likes/:id/", ({ request, params }) => {
+    if (!request.headers.get("Authorization")) return unauthorized();
+
+    const url = new URL(request.url);
+    const email = url.searchParams.get("email");
+    const target = url.searchParams.get("target");
+    if (!email || !isTarget(target)) {
+      return HttpResponse.json(
+        { error: "missing email or target" },
+        { status: 400 }
+      );
+    }
+
+    const id = Number(params.id);
+    const idx = likesStore.findIndex(
+      (l) => l.id === id && l.target === target && l.email === email
+    );
+    if (idx >= 0) likesStore.splice(idx, 1);
+    return new HttpResponse(null, { status: 204 });
+  }),
+];

--- a/src/mocks/handlers/likes.ts
+++ b/src/mocks/handlers/likes.ts
@@ -50,12 +50,9 @@ export const likesHandlers = [
     return HttpResponse.json({ likesCount: countLikes(commentid, "comment") });
   }),
 
-  /**
-   * GET /likes/:id/?email&target — has the user liked this target?
-   * 200 with the like record when found; 404 when not.
-   * `getLikeByUser` ignores the body on errors and treats undefined as "not
-   * liked", so a 404 surfaces as a clean falsy in calling code.
-   */
+  // GET /likes/:id/?email&target — always 200 with { liked: boolean }, matching
+  // the prod server contract (`bulletin/likes.py:like_or_not`). Consumers read
+  // `response.data.liked` (see `features/bulletin-board/hooks/useLike.ts`).
   http.get("*/likes/:id/", ({ request, params }) => {
     if (!request.headers.get("Authorization")) return unauthorized();
 
@@ -70,11 +67,7 @@ export const likesHandlers = [
     }
 
     const id = Number(params.id);
-    const record = findLike(id, email, target);
-    if (!record) {
-      return HttpResponse.json({ error: "not found" }, { status: 404 });
-    }
-    return HttpResponse.json(record);
+    return HttpResponse.json({ liked: Boolean(findLike(id, email, target)) });
   }),
 
   /**


### PR DESCRIPTION
Closes #170

## Summary
Mocks the 5 `/likes` endpoints consumed by `apis/likes/{queries,mutations}.ts`. A flat in-memory array keyed by `(target, id, email)` makes toggle, count, and per-user lookup trivial. Toggle invariant (POST then DELETE returns count to baseline) is asserted.

## Changes
- `src/mocks/fixtures/likes.ts` — `LikeRecord` shape + 6 seed records covering: post 10000 with 2 likers (`tester@umich.edu` + `alice@umich.edu`), post 10002 with 1 liker (`bob@umich.edu`), comment 1 with 2 likers, comment 3 with 1 liker. `getSeedLikes()` returns a fresh clone for `resetLikesStore`.
- `src/mocks/handlers/likes.ts` — `likesHandlers` with 5 handlers: GET `/posts/likes/:postid/`, GET `/comments/likes/:commentid/`, GET `/likes/:id/`, POST `/likes/:id/`, DELETE `/likes/:id/`. Specific count routes registered before the wildcard `/likes/:id/` GET so MSW route resolution picks the more-specific match (mirrors PR #195's readCount-vs-update precedent).
- `src/mocks/handlers/__tests__/likes.test.ts` — 21 cases covering: auth gates (401 without bearer), `target` discriminator (post vs comment routes), count endpoints (no auth, 0 baseline, derived from store), POST idempotency, DELETE removes + count decrements, toggle invariant in both directions (POST→DELETE and DELETE→POST), cross-user isolation, store reset.
- `src/mocks/handlers/index.ts` — register `likesHandlers`.

## Verification
- `npm test` → 188 pass / 3 pre-existing skips (no regressions); 21 new likes-suite cases all pass.
- `npx tsc --noEmit` clean.

## Scope tag
`[MECHANICAL]` `[TDD]`

## Notes
- POST is intentionally idempotent — a duplicate from the same `(id, target, email)` tuple is a no-op (returns the existing record with 201) so optimistic-UI double-fire doesn't inflate the count. If real backend differs, narrow this when 6.5d-consuming code (Lane 6.8 detail page) is wired up.
- DELETE returns 204 (matches 6.5c precedent) regardless of whether the like existed; no 404 on missing — keeps the toggle handler-side tolerant of races.
- Cross-lane fixture ids: post 10000–10002 align with 6.5b's range; comment 1, 3 are within 6.5c's seeded range. When all four MSW PRs land on `dev`, ids are coherent end-to-end.

---
_Routine: ds-client-migration autonomous, phase-6 nightly._

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCohXUgPBXAwREMBd7E8Vh)_