### PR TITLE
chore: add Claude Code GitHub automation (@claude)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,40 @@
+name: Claude Code
+
+# Runs Claude Code when "@claude" appears in an issue, an issue/PR comment,
+# or a PR review. Claude implements changes on a branch and opens a PR; it
+# never pushes to the default branch and never auto-merges.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Only run when the "@claude" trigger phrase is present.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,3 +74,45 @@ To develop against the production backend instead:
 ```bash
 npm run dev
 ```
+
+## GitHub Automation (when triggered by `@claude`)
+
+These rules apply when you are invoked from a GitHub issue or pull request (the `@claude` trigger). They are in addition to everything above.
+
+Being invoked via `@claude` is explicit authorization to commit to a working branch and open a pull request. This overrides the local "Never Push Without Explicit Permission" rule for automation runs only. It is never authorization to push to `main` or to merge.
+
+### Working style
+- Create small, focused pull requests. One concern per PR.
+- Never push directly to `main`. Always work on a branch and open a PR.
+- Never auto-merge. Codex review and the human owner decide.
+- Write a clear PR description with: a short summary of the change, the reason, the files touched, and the checks you ran with their results.
+
+### Risk level (required on every PR)
+Every PR you open MUST declare a risk level, both as a label and in the PR body:
+
+- `simple` — small, low-risk, well-contained change (copy, styling, isolated bug fix) with passing checks.
+- `complex` — multi-file or non-trivial logic change. Review more deeply, add or update tests, and run all checks before recommending approval.
+- `human-required` — touches a sensitive area (see below). Do not present it as safe to auto-approve; flag it for human review.
+
+Apply the label with `gh pr edit <number> --add-label <risk>`. Create the label first with `gh label create <risk>` if it does not exist.
+
+### Always mark `human-required`
+Mark the PR `human-required` if it touches any of:
+- payments / Stripe / Pocha order state
+- auth / JWT / admin permissions
+- database migrations or schema changes
+- secrets, credentials, or environment variables (including `src/constants/env.ts`)
+- deployment config or GitHub Actions workflows (`.github/`)
+- dependency upgrades (`package.json`, lockfiles)
+- anything security-sensitive
+
+### Checks before opening or updating a PR
+Run these and report their output in the PR body:
+
+```bash
+npx tsc --noEmit   # TypeScript type check
+npm run lint       # ESLint
+npm test           # vitest, when the change has test coverage
+```
+
+Do not finish with a broken build.


### PR DESCRIPTION
## Summary
Sets up Claude Code as the implementation agent for this repo, triggered by `@claude` in issues, comments, and PR reviews.

## Changes
- **`.github/workflows/claude.yml`** — runs `anthropics/claude-code-action@v1` on issue comments, PR review comments, PR reviews, and opened/assigned issues. Gated on the `@claude` trigger phrase. Permissions: `contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`, `actions: read`. Authenticates via `secrets.ANTHROPIC_API_KEY` (already configured).
- **`CLAUDE.md`** — operational rules for `@claude` runs: small focused PRs, no direct push to `main`, no auto-merge, required risk level (`simple` / `complex` / `human-required`), required checks, and the list of sensitive areas that must be marked `human-required` (payments/Stripe, auth/JWT, DB migrations, secrets/env, deploy/Actions, dependency upgrades).

## How it works once merged
Comment `@claude <request>` on an issue or PR. Claude creates a branch, implements the change, runs the repo's checks, and opens a PR with a risk level. It never pushes to `main` and never auto-merges — Codex review and human owners gate from there.

## Risk
`human-required` — this PR adds a GitHub Actions workflow, which is a sensitive area. Please review the trigger conditions and permissions before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)