### PR TITLE
docs: fix missing article in README setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ---
 
-### 1. run following command to install necessary packages
+### 1. run the following command to install necessary packages
 
 `npm install`
 


### PR DESCRIPTION
## Summary

Fixes a small typo in `README.md` where the article "the" was missing in the setup instructions:

```diff
- ### 1. run following command to install necessary packages
+ ### 1. run the following command to install necessary packages
```

## Files touched

- `README.md` (1 line)

## Checks

- `npx tsc --noEmit` — skipped (docs-only change, not applicable)
- `npm run lint` — skipped (docs-only change, not applicable)
- `npm test` — skipped (no test coverage for README)

## Risk level

`simple` — one-line documentation fix, no code paths affected.

Closes #205

Generated with [Claude Code](https://claude.ai/code)