### PR TITLE
feat: sequential auto-task dispatcher

### DIFF
--- a/.github/auto-tasks/README.md
+++ b/.github/auto-tasks/README.md
@@ -1,0 +1,42 @@
+# auto-tasks
+
+Manifests that drive the **sequential auto-task dispatcher** (`.github/workflows/task-dispatcher.yml`).
+
+Each plan lives in its own subdirectory:
+
+```
+.github/auto-tasks/<slug>/
+  plan.md      # the approved plan (provenance)
+  tasks.json   # ordered, atomic task manifest
+```
+
+`tasks.json` schema:
+
+```json
+{
+  "slug": "<kebab-slug>",
+  "paused": false,
+  "max_tasks": 20,
+  "tasks": [
+    { "id": 1, "order": 1, "title": "…", "body": "…", "depends_on": [], "status": "pending" }
+  ]
+}
+```
+
+## How it works
+
+1. Generate a manifest with the `/split-task` skill (after `/claudex` review of the plan).
+2. Commit `<slug>/` to the default branch (or merge a PR adding it). That starts the chain.
+3. The dispatcher opens the next eligible task as an `@claude` issue — one at a time, in dependency
+   order, only when no task is in flight — and advances one task per merged PR.
+4. Each issue runs the normal build loop (draft PR → `@codex review` → bridge). A human reviews and
+   merges every PR; nothing is auto-merged.
+
+## Controls
+
+- **Stop:** set `"paused": true` in the manifest, or set repo variable `AUTO_TASKS_ENABLED=false`.
+- **Cap:** `max_tasks` limits how many tasks the dispatcher will ever dispatch for a manifest.
+- The `id`, `status`, and `issue` fields are managed by the dispatcher once a chain is running — set
+  only `status: "pending"` when authoring; leave `issue` unset.
+
+Only one manifest progresses at a time (the first active one found).

--- a/.github/workflows/task-dispatcher.yml
+++ b/.github/workflows/task-dispatcher.yml
@@ -1,0 +1,145 @@
+name: Auto task dispatcher
+
+# Sequentially dispatches tasks from a manifest under .github/auto-tasks/<slug>/tasks.json.
+# Opens the next task as an "@claude" issue (via CLAUDE_PR_PAT, so claude.yml fires) only when no
+# task is in flight, advancing one task per merged PR. Respects task dependencies. Never merges.
+#
+# Start a chain: commit a manifest under .github/auto-tasks/ (see .claude/skills/split-task).
+# Stop: set "paused": true in the manifest, or repo variable AUTO_TASKS_ENABLED=false.
+on:
+  pull_request:
+    types: [closed]
+  push:
+    paths:
+      - '.github/auto-tasks/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: auto-task-dispatcher
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          token: ${{ secrets.CLAUDE_PR_PAT }}
+
+      - name: Dispatch next task
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_PR_PAT }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          AUTO_TASKS_ENABLED: ${{ vars.AUTO_TASKS_ENABLED }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "CLAUDE_PR_PAT is not set; cannot dispatch tasks."
+            exit 0
+          fi
+          if [ "${AUTO_TASKS_ENABLED:-true}" = "false" ]; then
+            echo "AUTO_TASKS_ENABLED=false; dispatcher disabled."
+            exit 0
+          fi
+
+          # A PR that closed without merging is not a task completion.
+          if [ "$EVENT" = "pull_request" ] && [ "${PR_MERGED:-}" != "true" ]; then
+            echo "PR closed without merge; ignoring."
+            exit 0
+          fi
+
+          # Find the first active manifest (not paused, has tasks that are not done).
+          shopt -s nullglob
+          MANIFEST=""
+          for f in .github/auto-tasks/*/tasks.json; do
+            if jq -e '(.paused != true) and ([.tasks[] | select(.status != "done")] | length > 0)' "$f" >/dev/null 2>&1; then
+              MANIFEST="$f"; break
+            fi
+          done
+          if [ -z "$MANIFEST" ]; then
+            echo "No active manifest with remaining tasks."
+            exit 0
+          fi
+          echo "Active manifest: $MANIFEST"
+
+          CHANGED=0
+          commit_manifest() {
+            git config user.name "kisa-auto-task[bot]"
+            git config user.email "actions@users.noreply.github.com"
+            git add "$MANIFEST"
+            git commit -m "$1 [skip ci]"
+            git push
+          }
+
+          # On a merged task PR (branch claude/issue-<N>-...), mark the matching task done.
+          if [ "$EVENT" = "pull_request" ] && [ "${PR_MERGED:-}" = "true" ]; then
+            N="$(printf '%s' "${PR_HEAD_REF:-}" | sed -nE 's#^claude/issue-([0-9]+).*#\1#p')"
+            if [ -n "$N" ] && jq -e --argjson n "$N" 'any(.tasks[]; .issue == $n)' "$MANIFEST" >/dev/null 2>&1; then
+              tmp="$(mktemp)"
+              jq --argjson n "$N" '(.tasks[] | select(.issue == $n) | .status) = "done"' "$MANIFEST" > "$tmp" && mv "$tmp" "$MANIFEST"
+              echo "Marked task with issue #$N as done."
+              CHANGED=1
+            fi
+          fi
+
+          # One task in flight at a time.
+          INFLIGHT="$(jq -r '[.tasks[] | select(.status == "dispatched")] | length' "$MANIFEST")"
+          if [ "${INFLIGHT:-0}" -gt 0 ]; then
+            echo "$INFLIGHT task(s) in flight; not dispatching another."
+            [ "$CHANGED" = "1" ] && commit_manifest "auto-tasks: mark task done"
+            exit 0
+          fi
+
+          # max_tasks cap (dispatched + done must not exceed it).
+          MAXT="$(jq -r '.max_tasks // 0' "$MANIFEST")"
+          USED="$(jq -r '[.tasks[] | select(.status != "pending")] | length' "$MANIFEST")"
+          if [ "${MAXT:-0}" -gt 0 ] && [ "${USED:-0}" -ge "${MAXT}" ]; then
+            echo "max_tasks ($MAXT) reached; not dispatching."
+            [ "$CHANGED" = "1" ] && commit_manifest "auto-tasks: mark task done"
+            exit 0
+          fi
+
+          # Pick the first pending task whose dependencies are all done.
+          NEXT_ID="$(jq -r '
+            (.tasks | map({(.id|tostring): .status}) | add) as $st
+            | [ .tasks[]
+                | select(.status == "pending")
+                | select((.depends_on // []) | all(. as $d | $st[($d|tostring)] == "done")) ][0].id // empty
+          ' "$MANIFEST")"
+
+          if [ -z "$NEXT_ID" ]; then
+            echo "No dispatchable pending task (dependencies unmet or none left)."
+            [ "$CHANGED" = "1" ] && commit_manifest "auto-tasks: mark task done"
+            REMAIN="$(jq -r '[.tasks[] | select(.status != "done")] | length' "$MANIFEST")"
+            [ "$REMAIN" = "0" ] && echo "All tasks complete for $MANIFEST."
+            exit 0
+          fi
+
+          TITLE="$(jq -r --argjson id "$NEXT_ID" '.tasks[] | select(.id == $id) | .title' "$MANIFEST")"
+          BODY="$(jq -r --argjson id "$NEXT_ID" '.tasks[] | select(.id == $id) | .body' "$MANIFEST")"
+          SLUG="$(jq -r '.slug // "auto-task"' "$MANIFEST")"
+
+          gh label create auto-task -R "$REPO" --color 1d76db --description "Auto-dispatched task from an auto-tasks manifest" --force >/dev/null 2>&1 || true
+
+          ISSUE_BODY="$(printf '@claude %s\n\n---\n_Auto-task `%s` (id %s) dispatched by task-dispatcher. Implement on a branch off the current default branch; a draft PR will be opened automatically._' "$BODY" "$SLUG" "$NEXT_ID")"
+          ISSUE_URL="$(gh issue create -R "$REPO" --title "[auto-task] $TITLE" --label auto-task --body "$ISSUE_BODY")"
+          ISSUE_NUM="$(printf '%s' "$ISSUE_URL" | sed -nE 's#.*/issues/([0-9]+)$#\1#p')"
+          echo "Opened issue #$ISSUE_NUM for task $NEXT_ID: $ISSUE_URL"
+
+          tmp="$(mktemp)"
+          jq --argjson id "$NEXT_ID" --argjson issue "${ISSUE_NUM:-0}" \
+            '(.tasks[] | select(.id == $id) | .status) = "dispatched"
+             | (.tasks[] | select(.id == $id) | .issue) = $issue' "$MANIFEST" > "$tmp" && mv "$tmp" "$MANIFEST"
+          commit_manifest "auto-tasks: dispatch task $NEXT_ID (issue #$ISSUE_NUM)"


### PR DESCRIPTION
Add the CI half of the planning/decomposition/dispatch layer.

- .github/workflows/task-dispatcher.yml: open tasks from a manifest as "@claude" issues one at a time, in dependency order, via CLAUDE_PR_PAT; advance one task per merged PR. Guards: one task in flight, max_tasks cap, paused/AUTO_TASKS_ENABLED kill switch, dependency gating. Never merges.
- .github/auto-tasks/README.md: manifest format and controls.

The /claudex and /split-task Claude Code skills are delivered separately (.claude is gitignored in this repo).

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshot / Video

add screenshots or a video to help explain your changes.
