### PR TITLE
Harden automation Layer 1 (trusted gate, diff-based risk, per-push opt-in)

### DIFF
--- a/.github/scripts/classify-risk.sh
+++ b/.github/scripts/classify-risk.sh
@@ -39,8 +39,10 @@ FILES="$(printf '%s' "$CMP" | jq -r '.files[] | .filename, (.previous_filename /
 [ -n "$FILES" ] || { echo "human-required"; exit 0; }
 
 # Sensitive paths -> always human-required. Pattern kept in one variable so it
-# cannot be accidentally line-wrapped.
-SENSITIVE='(^\.github/|(^|/)package(-lock)?\.json$|(^|/)yarn\.lock$|(^|/)pnpm-lock\.yaml$|src/constants/env|pocha|auth|jwt|admin|payment|stripe|secret|migration)'
+# cannot be accidentally line-wrapped. Covers this repo's real trust boundaries:
+# CI config, dependency manifests, env/secrets, the NextAuth middleware, ALL
+# server API routes (src/app/api/**), and auth/payment/upload-adjacent modules.
+SENSITIVE='(^\.github/|(^|/)package(-lock)?\.json$|(^|/)yarn\.lock$|(^|/)pnpm-lock\.yaml$|src/constants/env|(^|/)src/middleware\.(ts|js)$|(^|/)src/app/api/|(^|/)src/apis/|pocha|auth|jwt|admin|payment|stripe|cloudinary|customer|secret|migration)'
 if printf '%s\n' "$FILES" | grep -qiE "$SENSITIVE"; then
   echo "human-required"; exit 0
 fi

--- a/.github/scripts/classify-risk.sh
+++ b/.github/scripts/classify-risk.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Deterministically classify a PR's risk from its changed files.
+#   Usage: classify-risk.sh <base> <head>          (base/head = ref or SHA)
+#   Env (both REQUIRED):
+#     REPO=owner/repo
+#     GH_TOKEN=<token with contents:read>           # used by `gh api`
+#   Prints exactly one of: simple | complex | human-required
+#   Fails safe to human-required on an empty/unknown diff.
+#
+# SECURITY: only ever invoke the copy of this script from a trusted ref
+# (the default branch), never from a PR checkout -- a PR could otherwise edit
+# its own classifier.
+set -euo pipefail
+
+BASE="${1:?base ref/sha required}"
+HEAD="${2:?head ref/sha required}"
+: "${REPO:?REPO env (owner/repo) required}"
+: "${GH_TOKEN:?GH_TOKEN env (contents:read) required}"
+
+CMP="$(gh api "repos/${REPO}/compare/${BASE}...${HEAD}" 2>/dev/null || true)"
+[ -n "$CMP" ] || { echo "human-required"; exit 0; }
+
+FILES="$(printf '%s' "$CMP" | jq -r '.files[].filename // empty')"
+[ -n "$FILES" ] || { echo "human-required"; exit 0; }
+
+# Sensitive paths -> always human-required. Pattern kept in one variable so it
+# cannot be accidentally line-wrapped.
+SENSITIVE='(^\.github/|(^|/)package(-lock)?\.json$|(^|/)yarn\.lock$|(^|/)pnpm-lock\.yaml$|src/constants/env|pocha|auth|jwt|admin|payment|stripe|secret|migration)'
+if printf '%s\n' "$FILES" | grep -qiE "$SENSITIVE"; then
+  echo "human-required"; exit 0
+fi
+
+NFILES="$(printf '%s\n' "$FILES" | grep -c . || true)"
+CHANGES="$(printf '%s' "$CMP" | jq -r '[.files[] | (.additions + .deletions)] | add // 0')"
+if [ "${NFILES:-0}" -gt 5 ] || [ "${CHANGES:-0}" -gt 150 ]; then
+  echo "complex"
+else
+  echo "simple"
+fi

--- a/.github/scripts/classify-risk.sh
+++ b/.github/scripts/classify-risk.sh
@@ -17,7 +17,11 @@ HEAD="${2:?head ref/sha required}"
 : "${REPO:?REPO env (owner/repo) required}"
 : "${GH_TOKEN:?GH_TOKEN env (contents:read) required}"
 
-CMP="$(gh api "repos/${REPO}/compare/${BASE}...${HEAD}" 2>/dev/null || true)"
+# URL-encode each ref so the compare path is robust to slashes (e.g.
+# claude/issue-123-foo) and any other URL-unsafe characters in a branch name.
+# The "..." basehead separator stays literal between the two encoded refs.
+enc() { jq -rn --arg s "$1" '$s | @uri'; }
+CMP="$(gh api "repos/${REPO}/compare/$(enc "$BASE")...$(enc "$HEAD")" 2>/dev/null || true)"
 [ -n "$CMP" ] || { echo "human-required"; exit 0; }
 
 # The compare endpoint returns the changed-file list only on the first page and

--- a/.github/scripts/classify-risk.sh
+++ b/.github/scripts/classify-risk.sh
@@ -20,7 +20,18 @@ HEAD="${2:?head ref/sha required}"
 CMP="$(gh api "repos/${REPO}/compare/${BASE}...${HEAD}" 2>/dev/null || true)"
 [ -n "$CMP" ] || { echo "human-required"; exit 0; }
 
-FILES="$(printf '%s' "$CMP" | jq -r '.files[].filename // empty')"
+# The compare endpoint returns the changed-file list only on the first page and
+# caps it at 300 files for the whole comparison, so a larger diff could hide a
+# sensitive path outside the visible set. Fail closed when we hit the cap.
+# https://docs.github.com/en/rest/commits/commits#compare-two-commits
+NFILES="$(printf '%s' "$CMP" | jq '.files | length')"
+if [ "${NFILES:-0}" -ge 300 ]; then
+  echo "human-required"; exit 0
+fi
+
+# Classify both the new path AND the renamed-from path (previous_filename): a
+# rename OUT of a sensitive path must still count as sensitive.
+FILES="$(printf '%s' "$CMP" | jq -r '.files[] | .filename, (.previous_filename // empty)')"
 [ -n "$FILES" ] || { echo "human-required"; exit 0; }
 
 # Sensitive paths -> always human-required. Pattern kept in one variable so it
@@ -30,7 +41,7 @@ if printf '%s\n' "$FILES" | grep -qiE "$SENSITIVE"; then
   echo "human-required"; exit 0
 fi
 
-NFILES="$(printf '%s\n' "$FILES" | grep -c . || true)"
+# Size-based: use the real changed-file count (NFILES, not the rename-doubled list).
 CHANGES="$(printf '%s' "$CMP" | jq -r '[.files[] | (.additions + .deletions)] | add // 0')"
 if [ "${NFILES:-0}" -gt 5 ] || [ "${CHANGES:-0}" -gt 150 ]; then
   echo "complex"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,12 +17,18 @@ on:
 jobs:
   claude:
     # Require "@claude" AND a trusted actor; gates out drive-by non-collaborators.
+    # Exclude "allow-ai-fix": that phrase is the codex-bridge consent signal and must
+    # NOT start Claude directly -- only the bridge may post the vetted "@claude fix..."
+    # after its current-head Codex-finding and loop-guard checks pass.
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        !contains(github.event.comment.body, 'allow-ai-fix') &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        !contains(github.event.comment.body, 'allow-ai-fix') &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        !contains(github.event.review.body, 'allow-ai-fix') &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,12 +16,16 @@ on:
 
 jobs:
   claude:
-    # Only run when the "@claude" trigger phrase is present.
+    # Require "@claude" AND a trusted actor; gates out drive-by non-collaborators.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -51,6 +55,7 @@ jobs:
       - name: Open draft PR or request Codex review
         env:
           GH_TOKEN: ${{ secrets.CLAUDE_PR_PAT }}
+          REPO: ${{ github.repository }}
           BRANCH: ${{ steps.claude.outputs.branch_name }}
           BASE: ${{ github.event.repository.default_branch }}
           ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
@@ -83,16 +88,24 @@ jobs:
           fi
 
           TITLE="Claude: ${BRANCH}"
-          if [ -f /tmp/pr_title.txt ]; then
-            TITLE="$(head -n 1 /tmp/pr_title.txt)"
+          # Deterministic risk from the pushed diff (REPO/GH_TOKEN inherited from step env).
+          RISK="$(bash .github/scripts/classify-risk.sh "${BASE:-main}" "$BRANCH")"
+          echo "Computed risk level: $RISK"
+          # Preserve Claude's summary/checks if it wrote a body; else a short intro.
+          if [ -f /tmp/pr_body.md ]; then
+            BODY_SRC="$(cat /tmp/pr_body.md)"
+          else
+            BODY_SRC="Automated draft PR created by Claude Code."
           fi
-          if [ ! -f /tmp/pr_body.md ]; then
-            {
-              echo "Automated draft PR created by Claude Code."
-              echo
-              echo "Risk level: human-required (risk not reported by Claude; defaulting to human review)."
-            } > /tmp/pr_body.md
-          fi
+          # Strip any pre-existing "Risk level:" line so ours is authoritative.
+          BODY_SRC="$(printf '%s\n' "$BODY_SRC" | grep -viE '^[[:space:]]*risk level:' || true)"
+          {
+            printf '%s\n' "$BODY_SRC"
+            echo
+            echo "Risk level: ${RISK}"
+            echo
+            echo "_Risk classified deterministically from the diff; the bridge re-verifies from the default-branch classifier before any automated fix._"
+          } > /tmp/pr_body.md
           URL="$(gh pr create --draft --base "${BASE:-main}" --head "$BRANCH" \
             --title "$TITLE" --body-file /tmp/pr_body.md)"
           echo "Opened draft PR: $URL"

--- a/.github/workflows/codex-bridge.yml
+++ b/.github/workflows/codex-bridge.yml
@@ -5,16 +5,22 @@ name: Codex bridge
 # "@claude fix Codex feedback" using CLAUDE_PR_PAT so Claude pushes a fix to the
 # same PR branch. Codex only flags P0/P1, so any findings are treated as serious.
 #
+# Two ways a fix gets requested:
+#   1. Codex posts a serious (P0/P1 / changes_requested) finding, AND the PR's
+#      effective risk is `simple`/`complex`.
+#   2. A trusted human (OWNER/MEMBER/COLLABORATOR, not a bot) comments
+#      "@claude allow-ai-fix <head-sha>" on the PR conversation -- the active
+#      override for `human-required`/unclassified PRs. This path only fires when
+#      Codex has actually left a serious finding ON THE CURRENT HEAD.
+#
 # Safeguards:
 # - Never merges anything.
 # - Risk = the stricter of the PR body's declared level and a fresh diff
 #   classification run from the DEFAULT-BRANCH classifier (a PR cannot weaken
-#   its own risk). Only `simple`/`complex` auto-fix.
-# - `human-required` / unclassified PRs are deferred UNLESS a trusted human
-#   (OWNER/MEMBER/COLLABORATOR, not a bot) comments "@claude allow-ai-fix <head-sha>"
-#   where <head-sha> is a prefix of the current head SHA. Binding consent to the
-#   exact commit means it can't carry to a new head and can't be forged via a
-#   backdated commit date. A label is not used because Claude holds issues:write.
+#   its own risk).
+# - Opt-in consent is bound to the exact head SHA (a >=7-char prefix), so it
+#   can't carry to a new head and can't be forged via a backdated commit date.
+#   A label is not used because Claude holds issues:write and could self-apply.
 # - One automated fix round per PR, guarded by the `claude-fix-requested` label.
 on:
   pull_request_review:
@@ -95,30 +101,8 @@ jobs:
             PR="${ISSUE_COMMENT_PR:-}"
           fi
 
-          # Only react to Codex. (Logged so you can confirm the exact bot login and
-          # set the CODEX_BOT_LOGIN variable if this default is wrong.)
-          if [ "$AUTHOR" != "$CODEX_BOT" ]; then
-            echo "Event author '$AUTHOR' is not the Codex bot ('$CODEX_BOT'); skipping."
-            exit 0
-          fi
-
-          STATE="$(printf '%s' "$STATE" | tr '[:upper:]' '[:lower:]')"
-          if [ "$STATE" = "approved" ]; then
-            echo "Codex approved; nothing to fix."
-            exit 0
-          fi
-
-          # Serious if Codex requested changes or the text flags P0/P1 (the only
-          # severities Codex surfaces) or otherwise signals blocking issues.
-          SERIOUS=0
-          [ "$STATE" = "changes_requested" ] && SERIOUS=1
-          if printf '%s' "$BODY" | grep -iqE '(\bP0\b|\bP1\b|critical|blocker|blocking|changes requested)'; then
-            SERIOUS=1
-          fi
-          if [ "$SERIOUS" -ne 1 ]; then
-            echo "No serious (P0/P1) Codex findings detected; nothing to do."
-            exit 0
-          fi
+          # PR-level context needed by both trigger paths.
+          read -r BASE_SHA HEAD_SHA < <(gh api "repos/$REPO/pulls/$PR" --jq '"\(.base.sha) \(.head.sha)"')
 
           # Effective risk = stricter of (body-declared) and (fresh diff classification
           # via the DEFAULT-BRANCH classifier). A hand-edited body can't talk it down.
@@ -127,7 +111,6 @@ jobs:
             | grep -ioE 'risk level:[[:space:]]*`?(simple|complex|human-required)`?' \
             | head -n 1 | grep -ioE '(simple|complex|human-required)' \
             | head -n 1 | tr '[:upper:]' '[:lower:]' || true)"
-          read -r BASE_SHA HEAD_SHA < <(gh api "repos/$REPO/pulls/$PR" --jq '"\(.base.sha) \(.head.sha)"')
           DIFF_RISK="human-required"
           if [ -f .github/scripts/classify-risk.sh ]; then
             DIFF_RISK="$(bash .github/scripts/classify-risk.sh "$BASE_SHA" "$HEAD_SHA" || echo human-required)"
@@ -136,12 +119,11 @@ jobs:
           if [ "$(rank "$DIFF_RISK")" -ge "$(rank "$BODY_RISK")" ]; then RISK="$DIFF_RISK"; else RISK="$BODY_RISK"; fi
           echo "Risk: body='${BODY_RISK:-<none>}' diff='$DIFF_RISK' -> effective='$RISK'"
 
-          # Tamper-resistant opt-in BOUND TO THE EXACT HEAD COMMIT: a trusted human
-          # (OWNER/MEMBER/COLLABORATOR, not a bot) must comment
-          # "@claude allow-ai-fix <head-sha>" where <head-sha> is a >=7-char prefix of
-          # the current head SHA. Consent cannot carry to a different head, and -- unlike
-          # a committer-date comparison -- cannot be forged via a backdated commit. A
-          # label is deliberately NOT used (Claude holds issues:write and could self-apply).
+          # Opt-in BOUND TO THE EXACT HEAD COMMIT: a trusted human (OWNER/MEMBER/
+          # COLLABORATOR, not a bot) commented "@claude allow-ai-fix <head-sha>" on the
+          # PR conversation, where <head-sha> is a >=7-char prefix of the current head SHA.
+          # We scan ALL conversation comments (not just the triggering event) so this is
+          # reachable on the human's OWN comment event, not only on a later Codex event.
           OPT_IN=no
           # HEAD_SHA is a GitHub-issued hex SHA; safe to embed as a jq literal.
           OPT_IN_JQ='
@@ -155,20 +137,60 @@ jobs:
             OPT_IN=yes
           fi
 
-          # Only auto-fix `simple`/`complex`. `human-required` and unclassified PRs
-          # are deferred unless a trusted human opted in (above) for this exact head.
-          case "$RISK" in
-            simple|complex)
-              ;;
-            *)
-              if [ "$OPT_IN" = "yes" ]; then
-                echo "PR #$PR is '${RISK:-<none>}' but a trusted human approved '@claude allow-ai-fix' for head ${HEAD_SHA:0:12}; permitting one fix."
-              else
-                echo "PR #$PR is '${RISK:-<none>}'; deferring to a human (comment '@claude allow-ai-fix ${HEAD_SHA:0:12}' to permit one automated fix for this exact commit)."
-                exit 0
-              fi
-              ;;
-          esac
+          # Is the triggering event itself a serious Codex finding?
+          CODEX_SERIOUS=0
+          if [ "$AUTHOR" = "$CODEX_BOT" ]; then
+            STATE="$(printf '%s' "$STATE" | tr '[:upper:]' '[:lower:]')"
+            if [ "$STATE" = "approved" ]; then
+              echo "Codex approved; nothing to fix."
+              exit 0
+            fi
+            # Codex only surfaces P0/P1, so changes_requested or P0/P1 text is serious.
+            if [ "$STATE" = "changes_requested" ] || printf '%s' "$BODY" | grep -iqE '(\bP0\b|\bP1\b|critical|blocker|blocking|changes requested)'; then
+              CODEX_SERIOUS=1
+            fi
+          fi
+
+          # Does Codex have a serious finding ON THE CURRENT HEAD? Reviews and inline
+          # comments carry a commit_id we can bind to HEAD_SHA (issue-comment summaries do
+          # not, so they don't count). This gates the human opt-in path: a human may only
+          # authorize fixing findings that actually exist for this exact commit.
+          codex_flagged_head() {
+            local n
+            n="$( {
+              gh api "repos/$REPO/pulls/$PR/reviews" --paginate --jq '
+                [ .[] | select(.user.login=="'"$CODEX_BOT"'" and .commit_id=="'"$HEAD_SHA"'"
+                    and ((.state|ascii_upcase=="CHANGES_REQUESTED") or ((.body//"")|test("\\bP0\\b|\\bP1\\b|critical|blocker|blocking";"i")))) ] | length' 2>/dev/null
+              gh api "repos/$REPO/pulls/$PR/comments" --paginate --jq '
+                [ .[] | select(.user.login=="'"$CODEX_BOT"'" and .commit_id=="'"$HEAD_SHA"'") ] | length' 2>/dev/null
+            } | awk '{s+=$1} END{print s+0}')"
+            [ "${n:-0}" -gt 0 ]
+          }
+
+          # Decide whether to request a fix.
+          if [ "$CODEX_SERIOUS" = "1" ]; then
+            case "$RISK" in
+              simple|complex)
+                echo "Serious Codex finding on a '$RISK' PR; will request a fix." ;;
+              *)
+                if [ "$OPT_IN" = "yes" ]; then
+                  echo "Serious Codex finding on '${RISK:-<none>}' PR with a trusted opt-in for head ${HEAD_SHA:0:12}; will request a fix."
+                else
+                  echo "PR #$PR is '${RISK:-<none>}'; deferring to a human (comment '@claude allow-ai-fix ${HEAD_SHA:0:12}' on the PR to permit one automated fix for this exact commit)."
+                  exit 0
+                fi ;;
+            esac
+          elif [ "$OPT_IN" = "yes" ]; then
+            # Human opt-in is the trigger; only honour it if Codex actually flagged this head.
+            if ! codex_flagged_head; then
+              echo "Trusted opt-in present for head ${HEAD_SHA:0:12}, but no serious Codex finding on this head; nothing to fix."
+              exit 0
+            fi
+            echo "Trusted human opt-in for head ${HEAD_SHA:0:12} with an existing Codex finding; will request a fix."
+          else
+            echo "Event author '$AUTHOR' is not Codex and no trusted opt-in matches head ${HEAD_SHA:0:12}; skipping."
+            exit 0
+          fi
 
           # Loop guard: at most one automated fix round per PR.
           if gh pr view "$PR" -R "$REPO" --json labels --jq '.labels[].name' | grep -qx 'claude-fix-requested'; then

--- a/.github/workflows/codex-bridge.yml
+++ b/.github/workflows/codex-bridge.yml
@@ -11,9 +11,10 @@ name: Codex bridge
 #   classification run from the DEFAULT-BRANCH classifier (a PR cannot weaken
 #   its own risk). Only `simple`/`complex` auto-fix.
 # - `human-required` / unclassified PRs are deferred UNLESS a trusted human
-#   (OWNER/MEMBER/COLLABORATOR, not a bot) comments "@claude allow-ai-fix" after
-#   the current head commit (per-push consent; a label is not used because Claude
-#   itself holds issues:write).
+#   (OWNER/MEMBER/COLLABORATOR, not a bot) comments "@claude allow-ai-fix <head-sha>"
+#   where <head-sha> is a prefix of the current head SHA. Binding consent to the
+#   exact commit means it can't carry to a new head and can't be forged via a
+#   backdated commit date. A label is not used because Claude holds issues:write.
 # - One automated fix round per PR, guarded by the `claude-fix-requested` label.
 on:
   pull_request_review:
@@ -135,20 +136,21 @@ jobs:
           if [ "$(rank "$DIFF_RISK")" -ge "$(rank "$BODY_RISK")" ]; then RISK="$DIFF_RISK"; else RISK="$BODY_RISK"; fi
           echo "Risk: body='${BODY_RISK:-<none>}' diff='$DIFF_RISK' -> effective='$RISK'"
 
-          # Tamper-resistant, PER-PUSH opt-in: a trusted human (OWNER/MEMBER/COLLABORATOR,
-          # not a bot) must comment "@claude allow-ai-fix" AND that comment must be newer
-          # than the current head commit -- so consent never carries over after the branch
-          # changes. A label is deliberately NOT used (Claude holds issues:write and could
-          # self-apply one).
+          # Tamper-resistant opt-in BOUND TO THE EXACT HEAD COMMIT: a trusted human
+          # (OWNER/MEMBER/COLLABORATOR, not a bot) must comment
+          # "@claude allow-ai-fix <head-sha>" where <head-sha> is a >=7-char prefix of
+          # the current head SHA. Consent cannot carry to a different head, and -- unlike
+          # a committer-date comparison -- cannot be forged via a backdated commit. A
+          # label is deliberately NOT used (Claude holds issues:write and could self-apply).
           OPT_IN=no
-          HEAD_DATE="$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date')"
-          # HEAD_DATE is a GitHub-issued ISO-8601 timestamp; safe to embed as a jq literal.
-          OPT_IN_JQ='.[] | select(
-              (.author_association=="OWNER" or .author_association=="MEMBER" or .author_association=="COLLABORATOR")
-              and .user.type!="Bot"
-              and (.body | test("@claude[[:space:]]+allow-ai-fix";"i"))
-              and ((.created_at|fromdateiso8601) > ("'"$HEAD_DATE"'"|fromdateiso8601))
-            ) | .id'
+          # HEAD_SHA is a GitHub-issued hex SHA; safe to embed as a jq literal.
+          OPT_IN_JQ='
+            .[]
+            | select((.author_association=="OWNER" or .author_association=="MEMBER" or .author_association=="COLLABORATOR") and .user.type!="Bot")
+            | ((.body // "") | ascii_downcase) as $b
+            | (($b | capture("@claude[[:space:]]+allow-ai-fix[[:space:]]+(?<sha>[0-9a-f]{7,40})")?) | .sha) as $sha
+            | select($sha != null and ("'"$HEAD_SHA"'" | ascii_downcase | startswith($sha)))
+            | $sha'
           if gh api "repos/$REPO/issues/$PR/comments" --paginate --jq "$OPT_IN_JQ" | grep -q .; then
             OPT_IN=yes
           fi
@@ -160,9 +162,9 @@ jobs:
               ;;
             *)
               if [ "$OPT_IN" = "yes" ]; then
-                echo "PR #$PR is '${RISK:-<none>}' but a trusted human commented '@claude allow-ai-fix'; permitting one fix."
+                echo "PR #$PR is '${RISK:-<none>}' but a trusted human approved '@claude allow-ai-fix' for head ${HEAD_SHA:0:12}; permitting one fix."
               else
-                echo "PR #$PR is '${RISK:-<none>}'; deferring to a human (comment '@claude allow-ai-fix' AFTER the latest commit to permit one automated fix)."
+                echo "PR #$PR is '${RISK:-<none>}'; deferring to a human (comment '@claude allow-ai-fix ${HEAD_SHA:0:12}' to permit one automated fix for this exact commit)."
                 exit 0
               fi
               ;;

--- a/.github/workflows/codex-bridge.yml
+++ b/.github/workflows/codex-bridge.yml
@@ -59,11 +59,14 @@ jobs:
           REVIEW_AUTHOR: ${{ github.event.review.user.login }}
           REVIEW_STATE: ${{ github.event.review.state }}
           REVIEW_BODY: ${{ github.event.review.body }}
+          REVIEW_COMMIT: ${{ github.event.review.commit_id }}
           # PR number for review and review-comment events
           PR_EVENT_PR: ${{ github.event.pull_request.number }}
           # comment fields (shared by pull_request_review_comment and issue_comment)
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
           COMMENT_BODY: ${{ github.event.comment.body }}
+          # inline review comments carry the commit they were left on
+          COMMENT_COMMIT: ${{ github.event.comment.commit_id }}
           # issue_comment-on-PR fields
           ISSUE_COMMENT_PR_URL: ${{ github.event.issue.pull_request.url }}
           ISSUE_COMMENT_PR: ${{ github.event.issue.number }}
@@ -80,16 +83,21 @@ jobs:
           # the path Codex usually takes when it leaves P0/P1 findings as line-level
           # comments with an empty review summary -- without this case the bridge
           # never sees those findings.
+          # EVENT_COMMIT = the commit the triggering Codex event was bound to, when the
+          # event carries one (reviews and inline comments do; conversation comments
+          # don't). Used below to reject findings left on a now-stale head.
           if [ "$EVENT" = "pull_request_review" ]; then
             AUTHOR="${REVIEW_AUTHOR:-}"
             BODY="${REVIEW_BODY:-}"
             STATE="${REVIEW_STATE:-}"
             PR="${PR_EVENT_PR:-}"
+            EVENT_COMMIT="${REVIEW_COMMIT:-}"
           elif [ "$EVENT" = "pull_request_review_comment" ]; then
             AUTHOR="${COMMENT_AUTHOR:-}"
             BODY="${COMMENT_BODY:-}"
             STATE=""
             PR="${PR_EVENT_PR:-}"
+            EVENT_COMMIT="${COMMENT_COMMIT:-}"
           else
             if [ -z "${ISSUE_COMMENT_PR_URL:-}" ]; then
               echo "issue_comment is not on a PR; skipping."
@@ -99,6 +107,7 @@ jobs:
             BODY="${COMMENT_BODY:-}"
             STATE=""
             PR="${ISSUE_COMMENT_PR:-}"
+            EVENT_COMMIT=""
           fi
 
           # PR-level context needed by both trigger paths.
@@ -169,6 +178,19 @@ jobs:
 
           # Decide whether to request a fix.
           if [ "$CODEX_SERIOUS" = "1" ]; then
+            # Bind the finding to the reviewed head: a push landed after Codex reviewed
+            # must not let a stale finding authorize a fix on an unreviewed commit.
+            if [ -n "$EVENT_COMMIT" ]; then
+              if [ "$EVENT_COMMIT" != "$HEAD_SHA" ]; then
+                echo "Codex finding was on ${EVENT_COMMIT:0:12} but current head is ${HEAD_SHA:0:12}; PR advanced, skipping stale finding."
+                exit 0
+              fi
+            elif ! codex_flagged_head; then
+              # Conversation-comment finding can't be bound to a commit; require a fresh
+              # head-bound Codex finding (review / inline comment on the current head).
+              echo "Codex finding not bound to a commit and none found on current head ${HEAD_SHA:0:12}; skipping."
+              exit 0
+            fi
             case "$RISK" in
               simple|complex)
                 echo "Serious Codex finding on a '$RISK' PR; will request a fix." ;;

--- a/.github/workflows/codex-bridge.yml
+++ b/.github/workflows/codex-bridge.yml
@@ -7,8 +7,13 @@ name: Codex bridge
 #
 # Safeguards:
 # - Never merges anything.
-# - Only auto-triggers when the PR's declared risk level is `simple` or
-#   `complex`. Skips `human-required` and PRs with no declared risk.
+# - Risk = the stricter of the PR body's declared level and a fresh diff
+#   classification run from the DEFAULT-BRANCH classifier (a PR cannot weaken
+#   its own risk). Only `simple`/`complex` auto-fix.
+# - `human-required` / unclassified PRs are deferred UNLESS a trusted human
+#   (OWNER/MEMBER/COLLABORATOR, not a bot) comments "@claude allow-ai-fix" after
+#   the current head commit (per-push consent; a label is not used because Claude
+#   itself holds issues:write).
 # - One automated fix round per PR, guarded by the `claude-fix-requested` label.
 on:
   pull_request_review:
@@ -27,6 +32,14 @@ jobs:
   bridge:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout default branch (trusted classifier source)
+        uses: actions/checkout@v4
+        with:
+          # Pin to the default branch -- NEVER the PR merge ref -- so a PR that
+          # edits classify-risk.sh cannot influence its own risk decision.
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+
       - name: Maybe request a Claude fix
         env:
           GH_TOKEN: ${{ secrets.CLAUDE_PR_PAT }}
@@ -106,24 +119,52 @@ jobs:
             exit 0
           fi
 
-          # Only auto-fix when the PR declares risk as `simple` or `complex`.
-          # `human-required` and PRs with no declared risk are deferred to a human.
-          # (Read risk from the PR body; race-free vs labels.)
+          # Effective risk = stricter of (body-declared) and (fresh diff classification
+          # via the DEFAULT-BRANCH classifier). A hand-edited body can't talk it down.
           PR_BODY="$(gh pr view "$PR" -R "$REPO" --json body --jq '.body' || true)"
-          RISK="$(printf '%s' "$PR_BODY" \
+          BODY_RISK="$(printf '%s' "$PR_BODY" \
             | grep -ioE 'risk level:[[:space:]]*`?(simple|complex|human-required)`?' \
             | head -n 1 | grep -ioE '(simple|complex|human-required)' \
             | head -n 1 | tr '[:upper:]' '[:lower:]' || true)"
+          read -r BASE_SHA HEAD_SHA < <(gh api "repos/$REPO/pulls/$PR" --jq '"\(.base.sha) \(.head.sha)"')
+          DIFF_RISK="human-required"
+          if [ -f .github/scripts/classify-risk.sh ]; then
+            DIFF_RISK="$(bash .github/scripts/classify-risk.sh "$BASE_SHA" "$HEAD_SHA" || echo human-required)"
+          fi
+          rank() { case "$1" in human-required) echo 3;; complex) echo 2;; simple) echo 1;; *) echo 0;; esac; }
+          if [ "$(rank "$DIFF_RISK")" -ge "$(rank "$BODY_RISK")" ]; then RISK="$DIFF_RISK"; else RISK="$BODY_RISK"; fi
+          echo "Risk: body='${BODY_RISK:-<none>}' diff='$DIFF_RISK' -> effective='$RISK'"
+
+          # Tamper-resistant, PER-PUSH opt-in: a trusted human (OWNER/MEMBER/COLLABORATOR,
+          # not a bot) must comment "@claude allow-ai-fix" AND that comment must be newer
+          # than the current head commit -- so consent never carries over after the branch
+          # changes. A label is deliberately NOT used (Claude holds issues:write and could
+          # self-apply one).
+          OPT_IN=no
+          HEAD_DATE="$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date')"
+          # HEAD_DATE is a GitHub-issued ISO-8601 timestamp; safe to embed as a jq literal.
+          OPT_IN_JQ='.[] | select(
+              (.author_association=="OWNER" or .author_association=="MEMBER" or .author_association=="COLLABORATOR")
+              and .user.type!="Bot"
+              and (.body | test("@claude[[:space:]]+allow-ai-fix";"i"))
+              and ((.created_at|fromdateiso8601) > ("'"$HEAD_DATE"'"|fromdateiso8601))
+            ) | .id'
+          if gh api "repos/$REPO/issues/$PR/comments" --paginate --jq "$OPT_IN_JQ" | grep -q .; then
+            OPT_IN=yes
+          fi
+
+          # Only auto-fix `simple`/`complex`. `human-required` and unclassified PRs
+          # are deferred unless a trusted human opted in (above) for this exact head.
           case "$RISK" in
             simple|complex)
               ;;
-            human-required)
-              echo "PR #$PR is human-required; deferring to a human (no auto-fix)."
-              exit 0
-              ;;
             *)
-              echo "PR #$PR has no declared risk level ('${RISK:-<none>}'); deferring to a human (no auto-fix)."
-              exit 0
+              if [ "$OPT_IN" = "yes" ]; then
+                echo "PR #$PR is '${RISK:-<none>}' but a trusted human commented '@claude allow-ai-fix'; permitting one fix."
+              else
+                echo "PR #$PR is '${RISK:-<none>}'; deferring to a human (comment '@claude allow-ai-fix' AFTER the latest commit to permit one automated fix)."
+                exit 0
+              fi
               ;;
           esac
 

--- a/.github/workflows/risk-label.yml
+++ b/.github/workflows/risk-label.yml
@@ -1,8 +1,9 @@
 name: Risk label
 
-# Deterministically applies the risk label (simple / complex / human-required)
-# by parsing a "Risk level: <level>" line from the PR body. Runs on every PR so
-# the label reflects whatever the PR body currently declares.
+# Deterministically applies the risk label (simple / complex / human-required).
+# The label reflects the EFFECTIVE risk: the stricter of the PR body's declared
+# "Risk level:" line and a fresh diff classification (.github/scripts/classify-risk.sh),
+# so the visible label matches the gate the codex-bridge actually enforces.
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
@@ -16,11 +17,19 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - name: Apply risk label from PR body
+      - name: Checkout default branch (trusted classifier source)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+
+      - name: Apply effective risk label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           # Passed via env (never inlined into the script) to avoid injection.
           BODY: ${{ github.event.pull_request.body }}
         run: |
@@ -31,21 +40,31 @@ jobs:
           gh label create complex        -R "$REPO" --color fbca04 --description "Non-trivial logic; deeper review needed" --force >/dev/null 2>&1 || true
           gh label create human-required -R "$REPO" --color b60205 --description "Sensitive area; requires human review, no auto-approve" --force >/dev/null 2>&1 || true
 
-          # Extract the declared risk level (case-insensitive, optional backticks).
-          RISK="$(printf '%s' "$BODY" \
+          # Risk declared in the PR body (case-insensitive, optional backticks).
+          BODY_RISK="$(printf '%s' "$BODY" \
             | grep -ioE 'risk level:[[:space:]]*`?(simple|complex|human-required)`?' \
             | head -n 1 \
             | grep -ioE '(simple|complex|human-required)' \
             | head -n 1 \
             | tr '[:upper:]' '[:lower:]' || true)"
 
+          # Risk classified from the diff (fall back to body-only if script absent).
+          DIFF_RISK=""
+          if [ -f .github/scripts/classify-risk.sh ]; then
+            DIFF_RISK="$(bash .github/scripts/classify-risk.sh "$BASE_SHA" "$HEAD_SHA" || true)"
+          fi
+
+          # Effective risk = the stricter of the two.
+          rank() { case "$1" in human-required) echo 3;; complex) echo 2;; simple) echo 1;; *) echo 0;; esac; }
+          if [ "$(rank "$DIFF_RISK")" -ge "$(rank "$BODY_RISK")" ]; then RISK="$DIFF_RISK"; else RISK="$BODY_RISK"; fi
+
           if [ -z "${RISK:-}" ]; then
-            echo "No 'Risk level:' line found in PR body; leaving labels unchanged."
+            echo "No risk determinable (no body line, no diff); leaving labels unchanged."
             exit 0
           fi
-          echo "Declared risk level: $RISK"
+          echo "Effective risk: body='${BODY_RISK:-<none>}' diff='${DIFF_RISK:-<none>}' -> '$RISK'"
 
-          # Remove any stale risk labels, then apply the declared one.
+          # Remove any stale risk labels, then apply the effective one.
           for l in simple complex human-required; do
             if [ "$l" != "$RISK" ]; then
               gh pr edit "$PR" -R "$REPO" --remove-label "$l" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Layer 1 hardening (Claude/Codex automation)

Addresses Codex's review of the automation architecture. **Layer 1 only** — the dispatcher is intentionally out of scope (it needs off-`main` state tracking first).

### Changes
1. **Trusted-actor gate** (`claude.yml`) — `@claude` now also requires `author_association ∈ {OWNER, MEMBER, COLLABORATOR}`, so drive-by comments from non-collaborators can't start a write-capable run. The bridge's `@claude fix` and dispatcher issues are posted via the PAT (as `ysna99`), so the loop still passes the gate.
2. **Deterministic, diff-based risk** — new `.github/scripts/classify-risk.sh` is the single source of classification (sensitive paths → `human-required`; >5 files or >150 lines → `complex`; else `simple`; fail-safe to `human-required` on an empty/unknown diff). `claude.yml` now computes risk from the pushed diff and **preserves Claude's PR body** (strips/replaces only the `Risk level:` line) instead of overwriting it.
3. **Tamper-resistant gate** — both `risk-label.yml` and `codex-bridge.yml` run the classifier from a **default-branch checkout** (never the PR's copy) and take the **stricter** of body-declared vs diff-classified risk. The label now matches the gate the bridge enforces.
4. **Per-push human opt-in** — `human-required`/unclassified PRs are deferred unless a trusted human (OWNER/MEMBER/COLLABORATOR, non-bot) comments `@claude allow-ai-fix` **newer than the current head commit**. A label is deliberately not used (Claude holds `issues:write` and could self-apply one). Still capped at one fix round by `claude-fix-requested`.

### Validation
`bash -n` on the script and all embedded `run:` blocks, YAML parse on all three workflows, and a unit check of the opt-in jq filter (matches only the newer, trusted comment) all pass locally.

### Deferred (separate PR)
Dispatcher idempotency + moving manifest progress off protected `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
