### PR TITLE
docs(CLAUDE.md): add Working Guidelines section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,71 @@
 # CLAUDE.md
 
-Covers: project architecture, task-specific instructions (where to work and which skills to invoke), verification requirements, critical rules, and local development setup.
+Covers: working guidelines, project architecture, task-specific instructions (where to work and which skills to invoke), verification requirements, critical rules, and local development setup.
+
+## Working Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with the project-specific instructions below as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
 
 ## Architecture Overview
 


### PR DESCRIPTION
## Summary
Adds a **Working Guidelines** section to `CLAUDE.md` so the automated `@claude` developer follows a consistent set of behavioral guidelines on every run: Think Before Coding, Simplicity First, Surgical Changes, and Goal-Driven Execution.

## Reason
Requested: bake these guidelines into the repo's `CLAUDE.md` so they apply to every automation run rather than being restated per task.

## Files touched
- `CLAUDE.md` — new `## Working Guidelines` section (nested `###` items under the existing h1); `Covers:` index line updated to mention it. No project-specific instructions changed.

## Checks
Docs-only change. Diff is purely additive aside from the one-line `Covers:` index update; no emojis introduced (the `→` arrows already appear in the existing doc).

## Note (separate follow-up)
The existing "Risk level (required on every PR)" / "Opening the pull request" sections (the `/tmp/pr_title.txt` + `/tmp/pr_body.md` handoff and the "defaulted to human-required" wording) will become stale once #213 merges, since `claude.yml` then classifies risk deterministically from the diff. Intentionally **not** changed here to keep this PR surgical; worth a separate docs PR after #213.

Risk level: simple
