### PR TITLE
chore(deps): bump @stripe/react-stripe-js to 3.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@radix-ui/react-dropdown-menu": "2.1.15",
         "@radix-ui/react-popover": "1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
-        "@stripe/react-stripe-js": "2.9.0",
+        "@stripe/react-stripe-js": "3.10.0",
         "@stripe/stripe-js": "4.10.0",
         "@tailwindcss/postcss": "4.2.2",
         "@umichkisa-ds/form": "1.0.1",
@@ -11998,17 +11998,17 @@
       "license": "MIT"
     },
     "node_modules/@stripe/react-stripe-js": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-2.9.0.tgz",
-      "integrity": "sha512-+/j2g6qKAKuWSurhgRMfdlIdKM+nVVJCy/wl0US2Ccodlqx0WqfIIBhUkeONkCG+V/b+bZzcj4QVa3E/rXtT4Q==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.10.0.tgz",
+      "integrity": "sha512-UPqHZwMwDzGSax0ZI7XlxR3tZSpgIiZdk3CiwjbTK978phwR/fFXeAXQcN/h8wTAjR4ZIAzdlI9DbOqJhuJdeg==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@stripe/stripe-js": "^1.44.1 || ^2.0.0 || ^3.0.0 || ^4.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
       }
     },
     "node_modules/@stripe/stripe-js": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-dropdown-menu": "2.1.15",
     "@radix-ui/react-popover": "1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
-    "@stripe/react-stripe-js": "2.9.0",
+    "@stripe/react-stripe-js": "3.10.0",
     "@stripe/stripe-js": "4.10.0",
     "@tailwindcss/postcss": "4.2.2",
     "@umichkisa-ds/form": "1.0.1",


### PR DESCRIPTION
## Summary

PR 0d of the Next 15 / React 19 migration prep. Stacked on #219. Payments area — expect human-required classification; please run a test-card payment before merging.

@stripe/react-stripe-js v2 peer-pins React to ^18 and would block the React 19 upgrade. v3.10.0 declares react >=16.8 <20 and accepts the existing @stripe/stripe-js@4.10.0 (peer >=1.44.1 <8.0.0), so no companion bump is needed. v3 also remains fully React 18 compatible, so this ships safely ahead of the framework flip.

The app uses only stable APIs: Elements (pocha/pay/page.tsx), useStripe/useElements (useStripePayment.ts), PaymentElement (PaymentSubmitForm.tsx). Zero code changes; package.json + lockfile only.

## Browser verification (headless Chrome, mobile viewport, MSW mock mode)
- Full Pocha flow: menu loads, item modal, add to cart, cart page, Proceed to /pocha/pay
- Stripe PaymentElement mounts and renders card number / expiry / CVC / Link / country fields (live Stripe iframes)
- No console or page errors

Not exercised: actual test-card payment submission — left for human verification per payment-area policy.

## Checks
- npx tsc --noEmit: clean
- npm run lint: 0 errors
- npm test: 265 passed, 3 skipped
- npm run build: succeeds