### PR TITLE
Adopt hardened agentic-ci template (capped fix rounds, dispatcher, auto-merge off by default)

### DIFF
--- a/.github/auto-tasks/README.md
+++ b/.github/auto-tasks/README.md
@@ -1,0 +1,83 @@
+# auto-tasks
+
+Manifests that drive the **stateless auto-task dispatcher**
+(`.github/workflows/task-dispatcher.yml` -> `.github/scripts/dispatch-tasks.sh`).
+
+Each plan lives in its own subdirectory:
+
+```
+.github/auto-tasks/<slug>/
+  plan.md      # the approved plan (provenance; optional)
+  tasks.json   # ordered, immutable task manifest
+```
+
+## tasks.json: an immutable spec
+
+You author it once; the dispatcher **never writes it back**. There are no
+`status`, `issue`, or `order` fields: array order is the order, and task state is
+derived from GitHub on every run (see below).
+
+```json
+{
+  "slug": "refactor-foo",
+  "paused": false,
+  "max_tasks": 20,
+  "tasks": [
+    { "id": 1, "title": "Extract helper", "body": "what @claude should do", "depends_on": [] },
+    { "id": 2, "title": "Migrate callers", "body": "...", "depends_on": [1] }
+  ]
+}
+```
+
+- `slug`: kebab id for the chain; also the label prefix (`at:<slug>-<id>`).
+- `paused`: `true` freezes the whole manifest.
+- `max_tasks`: hard cap on how many task issues this manifest will ever open.
+- `tasks[]`: `id` (unique integer), `title`, `body` (the `@claude` instruction),
+  `depends_on` (ids that must be **done** first).
+
+## Derived state (no stored progress)
+
+Each run derives every task's state from issues/PRs. Nothing is persisted, so
+there is no write to the protected default branch:
+
+| State | Meaning |
+|-------|---------|
+| **PENDING**   | no `at:<slug>-<id>` issue exists yet |
+| **IN_FLIGHT** | that issue exists, is open, and no merged PR has completed it |
+| **DONE**      | a merged PR with head `claude/issue-<N>-*` exists (`N` = the task's issue number) |
+| **BLOCKED**   | the issue is **closed** and there is no such merged PR (a human said no) |
+
+Task-to-issue binding is the unique label **`at:<slug>-<id>`** the dispatcher puts
+on each issue it opens (plus an `<!-- auto-task slug=... id=... -->` marker in the body).
+
+## How it works
+
+1. Generate a manifest with the `/split-task` skill (after the plan is reviewed).
+2. Merge a PR that adds `<slug>/tasks.json` with `"paused": false`. That merge
+   (a `pull_request: closed` event) kicks off the dispatcher. Or run the workflow
+   manually (`gh workflow run "Auto task dispatcher"`).
+3. The dispatcher opens the first eligible task (deps all **DONE**) as an `@claude`
+   issue via `CLAUDE_PR_PAT`, one at a time, only when nothing is **IN_FLIGHT**,
+   and advances one task per merged PR.
+4. Each issue runs the normal build loop (draft PR, `@codex review`, bridge).
+   A human reviews and merges every PR; **nothing is auto-merged**.
+5. If a task issue is **closed without** a merged `claude/issue-<N>-*` PR, the
+   dispatcher treats it as **BLOCKED**, comments once, and **stops the chain**
+   (all manifests hold, not just this one, until it is resolved).
+
+## Controls
+
+- **Stop:** set `"paused": true`, or set repo variable `AUTO_TASKS_ENABLED=false`.
+- **Reject a task:** close the task **issue** (not just its PR). A closed PR with
+  an open issue keeps the task IN_FLIGHT and the chain just waits; closing the
+  issue is the "no" signal the dispatcher acts on.
+- **Resume after a block:** complete/reopen the blocked task, then re-run the
+  workflow (`gh workflow run ...`) or merge any PR to re-trigger.
+- Only one manifest progresses at a time (the first non-paused one with work left).
+
+## Requirements
+
+- Secret **`CLAUDE_PR_PAT`** (issues opened by the default `GITHUB_TOKEN` do not
+  trigger `claude.yml`; a human-owned PAT does).
+- The base loop (`claude.yml`, draft PR, Codex, bridge) unchanged.
+- Workflow token needs only `contents: read` (checkout); all writes use the PAT.

--- a/.github/auto/sensitive-paths.txt
+++ b/.github/auto/sensitive-paths.txt
@@ -1,0 +1,22 @@
+# Per-repo trust boundaries for classify-risk.sh (KISA-website-client).
+#
+# One POSIX extended-regex fragment per line. Blank lines and '#' comments are
+# ignored. Every changed file path (and rename-source path) in a PR is matched
+# against these; any hit forces the PR to human-required (never auto-merged).
+#
+# classify-risk.sh already covers UNIVERSAL boundaries on its own, so do not
+# repeat them here:
+#   .github/, dependency manifests+lockfiles (npm/pip/go/cargo/gem), .env files,
+#   and the keywords: secret auth jwt admin payment migration
+#
+# This file is read from the DEFAULT branch only -- a PR cannot weaken its own
+# classification by editing it.
+
+src/constants/env                 # env constants module (src/constants/env.ts)
+(^|/)src/middleware\.(ts|js)$     # NextAuth middleware
+(^|/)src/app/api/                 # server API routes
+(^|/)src/apis/                    # API client layer
+pocha                             # Pocha order state / payments surface
+stripe                            # payments
+cloudinary                        # uploads
+customer                          # customer data

--- a/.github/scripts/classify-risk.sh
+++ b/.github/scripts/classify-risk.sh
@@ -38,12 +38,26 @@ fi
 FILES="$(printf '%s' "$CMP" | jq -r '.files[] | .filename, (.previous_filename // empty)')"
 [ -n "$FILES" ] || { echo "human-required"; exit 0; }
 
-# Sensitive paths -> always human-required. Pattern kept in one variable so it
-# cannot be accidentally line-wrapped. Covers this repo's real trust boundaries:
-# CI config, dependency manifests, env/secrets, the NextAuth middleware, ALL
-# server API routes (src/app/api/**), and auth/payment/upload-adjacent modules.
-SENSITIVE='(^\.github/|(^|/)package(-lock)?\.json$|(^|/)yarn\.lock$|(^|/)pnpm-lock\.yaml$|src/constants/env|(^|/)src/middleware\.(ts|js)$|(^|/)src/app/api/|(^|/)src/apis/|pocha|auth|jwt|admin|payment|stripe|cloudinary|customer|secret|migration)'
-if printf '%s\n' "$FILES" | grep -qiE "$SENSITIVE"; then
+# Sensitive paths -> always human-required. A universal BASE covers boundaries
+# true for any repo: CI/automation config, dependency manifests+lockfiles across
+# common ecosystems (npm/pip/go/cargo/gem), dotenv files, and the keywords
+# secret/auth/jwt/admin/payment/migration. Repo-specific boundaries are declared
+# in .github/auto/sensitive-paths.txt (one extended-regex fragment per line;
+# '#' comments and blank lines ignored) and OR-ed in. Absent/empty file -> base
+# only (still safe). SECURITY: that config, like this script, is read only from
+# the trusted default branch -- a PR must not weaken its own classification.
+SENSITIVE_BASE='(^\.github/|(^|/)(package(-lock)?\.json|yarn\.lock|pnpm-lock\.yaml|requirements\.txt|Pipfile(\.lock)?|go\.(mod|sum)|Cargo\.(toml|lock)|Gemfile(\.lock)?)$|(^|/)\.env|secret|auth|jwt|admin|payment|migration)'
+EXTRA="$(sed -E 's/#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//' "$(dirname "$0")/../auto/sensitive-paths.txt" 2>/dev/null | awk 'NF' | paste -sd'|' - || true)"
+if [ -n "$EXTRA" ]; then SENSITIVE="(${SENSITIVE_BASE}|${EXTRA})"; else SENSITIVE="$SENSITIVE_BASE"; fi
+# grep rc: 0=match, 1=no match, >=2=error (e.g. a malformed regex line in
+# sensitive-paths.txt). An error must fail CLOSED: inside a bare `if` it would
+# read as "no match" and one bad config line would silently disable the whole
+# sensitive check, built-in BASE patterns included.
+set +e
+printf '%s\n' "$FILES" | grep -qiE "$SENSITIVE"
+GREP_RC=$?
+set -e
+if [ "$GREP_RC" -ne 1 ]; then
   echo "human-required"; exit 0
 fi
 

--- a/.github/scripts/dispatch-tasks.sh
+++ b/.github/scripts/dispatch-tasks.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Stateless auto-task dispatcher.
+#
+# Reads IMMUTABLE manifests from the working tree (.github/auto-tasks/<slug>/tasks.json),
+# derives every task's state from GitHub issues/PRs on each run, and opens at most ONE new
+# "@claude" task issue per invocation. It never writes the manifest, never pushes to the
+# (protected) default branch, and never merges anything -- that removes the old dispatcher's
+# root flaw (committing manifest progress back to a protected branch).
+#
+# Task<->issue binding: each task carries a unique label  at:<slug>-<id>.
+# Per-task derived state:
+#   PENDING   - no  at:<slug>-<id>  issue exists yet
+#   IN_FLIGHT - that issue exists, is open, and no merged PR has completed it
+#   DONE      - a merged PR with head  claude/issue-<N>-*  exists (N = the task's issue number)
+#   BLOCKED   - the issue is closed and there is no such merged PR (a human said "no")
+#
+# BLOCKED stops the chain (we do not barrel past a human's "no"). One task advances per merged PR.
+#
+# Env:
+#   REPO                owner/name             (required)
+#   GH_TOKEN            CLAUDE_PR_PAT          (required: issues are opened as a human so claude.yml fires)
+#   EVENT               github.event_name      (optional: "pull_request" gets the merge guard below)
+#   PR_MERGED           true|false             (optional: only meaningful for a pull_request event)
+#   AUTO_TASKS_ENABLED  true|false             (optional: "false" disables the dispatcher)
+#   MANIFEST_GLOB       override for tests     (default .github/auto-tasks/*/tasks.json)
+set -euo pipefail
+
+REPO="${REPO:?REPO is required}"
+: "${GH_TOKEN:?GH_TOKEN (CLAUDE_PR_PAT) is required}"
+EVENT="${EVENT:-}"
+MANIFEST_GLOB="${MANIFEST_GLOB:-.github/auto-tasks/*/tasks.json}"
+
+if [ "${AUTO_TASKS_ENABLED:-true}" = "false" ]; then
+  echo "AUTO_TASKS_ENABLED=false; dispatcher disabled."
+  exit 0
+fi
+# A PR that closed without merging is not a task completion; nothing to advance.
+if [ "$EVENT" = "pull_request" ] && [ "${PR_MERGED:-}" != "true" ]; then
+  echo "PR closed without merge; nothing to advance."
+  exit 0
+fi
+
+# --- GitHub state providers (overridable in tests by defining these before sourcing) ---
+if ! declare -F merged_heads >/dev/null; then
+  # All merged-PR head branch names, newline separated.
+  # ponytail: last 200 merged PRs; raise --limit if a chain ever spans >200 merges.
+  merged_heads() { gh pr list -R "$REPO" --state merged --limit 200 --json headRefName --jq '.[].headRefName'; }
+fi
+if ! declare -F issue_for_label >/dev/null; then
+  # First issue (any state) carrying a label -> "<number> <OPEN|CLOSED>", or empty.
+  issue_for_label() {
+    gh issue list -R "$REPO" --label "$1" --state all --json number,state \
+      --jq '.[0] | if . == null then empty else "\(.number) \(.state)" end'
+  }
+fi
+
+MERGED_HEADS="$(merged_heads || true)"
+is_done() { printf '%s\n' "$MERGED_HEADS" | grep -qE "^claude/issue-$1(-|\$)"; }
+
+shopt -s nullglob
+for MANIFEST in $MANIFEST_GLOB; do
+  jq -e '.paused != true' "$MANIFEST" >/dev/null 2>&1 || { echo "Paused, skipping: $MANIFEST"; continue; }
+  SLUG="$(jq -r '.slug // "auto-task"' "$MANIFEST")"
+  MAXT="$(jq -r '.max_tasks // 0' "$MANIFEST")"
+  echo "== $MANIFEST (slug=$SLUG) =="
+
+  # STATE is an indexed array keyed by the integer task id (portable to bash 3.2).
+  unset STATE; declare -a STATE=()
+  BLOCKED_N=""; INFLIGHT=0; USED=0
+  IDS=(); while IFS= read -r x; do IDS+=("$x"); done < <(jq -r '.tasks[].id' "$MANIFEST")
+
+  # Pass 1: derive each task's state.
+  for ID in ${IDS[@]+"${IDS[@]}"}; do
+    INFO="$(issue_for_label "at:$SLUG-$ID" || true)"
+    if [ -z "$INFO" ]; then STATE[$ID]=PENDING; continue; fi
+    N="${INFO%% *}"; ISTATE="${INFO##* }"; USED=$((USED+1))
+    if is_done "$N"; then STATE[$ID]=DONE
+    elif [ "$ISTATE" = "CLOSED" ]; then STATE[$ID]=BLOCKED; [ -z "$BLOCKED_N" ] && BLOCKED_N="$N"
+    else STATE[$ID]=IN_FLIGHT; INFLIGHT=$((INFLIGHT+1)); fi
+  done
+
+  # A human closed a task issue without a merged PR -> stop dispatching.
+  # Deliberately halts EVERY manifest, not just this slug: a human said "no"
+  # somewhere, and we don't barrel past that anywhere.
+  if [ -n "$BLOCKED_N" ]; then
+    echo "Task issue #$BLOCKED_N closed without a merged PR; halting ALL dispatching until resolved."
+    MARK="auto-task-dispatcher: chain stopped"
+    if ! gh issue view "$BLOCKED_N" -R "$REPO" --json comments --jq '.comments[].body' 2>/dev/null | grep -qF "$MARK"; then
+      gh issue comment "$BLOCKED_N" -R "$REPO" --body "$MARK for \`$SLUG\`. This task issue was closed without a merged \`claude/issue-$BLOCKED_N-*\` PR, so it is treated as blocked and no further tasks will be opened -- in ANY manifest -- until it is resolved. Complete or reopen this task (or set \`\"paused\": true\`), then re-run the dispatcher to resume."
+    fi
+    exit 0
+  fi
+
+  # One task in flight at a time (globally).
+  if [ "$INFLIGHT" -gt 0 ]; then echo "$INFLIGHT task(s) in flight; not dispatching."; exit 0; fi
+
+  # max_tasks caps total issues ever opened for this manifest.
+  if [ "$MAXT" -gt 0 ] && [ "$USED" -ge "$MAXT" ]; then
+    echo "max_tasks ($MAXT) reached for $SLUG; nothing more to dispatch."; continue
+  fi
+
+  # First PENDING task (manifest order) whose dependencies are all DONE.
+  NEXT_ID=""
+  for ID in ${IDS[@]+"${IDS[@]}"}; do
+    [ "${STATE[$ID]}" = "PENDING" ] || continue
+    OK=1
+    while IFS= read -r D; do
+      [ -z "$D" ] && continue
+      [ "${STATE[$D]:-}" = "DONE" ] || { OK=0; break; }
+    done < <(jq -r --argjson id "$ID" '.tasks[]|select(.id==$id)|(.depends_on // [])[]' "$MANIFEST")
+    if [ "$OK" = "1" ]; then NEXT_ID="$ID"; break; fi
+  done
+  if [ -z "$NEXT_ID" ]; then
+    echo "No dispatchable task in $SLUG (all done or dependencies unmet)."; continue
+  fi
+
+  # Check-then-create guard: re-verify the label is still absent right before creating.
+  if [ -n "$(issue_for_label "at:$SLUG-$NEXT_ID" || true)" ]; then
+    echo "Race: at:$SLUG-$NEXT_ID appeared; skipping."; exit 0
+  fi
+
+  TITLE="$(jq -r --argjson id "$NEXT_ID" '.tasks[]|select(.id==$id)|.title' "$MANIFEST")"
+  BODY="$(jq -r --argjson id "$NEXT_ID" '.tasks[]|select(.id==$id)|.body' "$MANIFEST")"
+  gh label create "auto-task" -R "$REPO" --color 1d76db --description "Auto-dispatched task" --force >/dev/null 2>&1 || true
+  gh label create "at:$SLUG-$NEXT_ID" -R "$REPO" --color 5319e7 --description "auto-task $SLUG id $NEXT_ID" --force >/dev/null 2>&1 || true
+  ISSUE_BODY="$(printf '@claude %s\n\n<!-- auto-task slug=%s id=%s -->\n\n---\n_Auto-task `%s` (id %s), dispatched by task-dispatcher. Implement on a branch off the default branch; a draft PR opens automatically and a human reviews + merges it._' \
+    "$BODY" "$SLUG" "$NEXT_ID" "$SLUG" "$NEXT_ID")"
+  URL="$(gh issue create -R "$REPO" --title "[auto-task] $TITLE" --label "auto-task" --label "at:$SLUG-$NEXT_ID" --body "$ISSUE_BODY")"
+  echo "Opened $URL for task $NEXT_ID."
+  exit 0
+done
+
+echo "No manifest had a dispatchable task."

--- a/.github/scripts/effective-risk.sh
+++ b/.github/scripts/effective-risk.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Effective risk of an existing PR: the STRICTER of the PR body's declared
+# "Risk level:" line and a fresh diff classification (classify-risk.sh), so a
+# hand-edited body can never weaken the classifier's floor.
+#   Usage: effective-risk.sh <pr-number>
+#   Env (both REQUIRED):
+#     REPO=owner/repo
+#     GH_TOKEN=<token with contents:read + pull_requests:read>
+#   Prints exactly one of: simple | complex | human-required
+#
+# Single source of truth for codex-bridge.yml, risk-label.yml and
+# auto-merge.yml, which previously carried three copy-pasted versions of this
+# computation that could drift apart.
+#
+# SECURITY: like classify-risk.sh, only ever invoke the copy of this script
+# from a trusted ref (the default branch), never from a PR checkout.
+set -euo pipefail
+
+PR="${1:?pr number required}"
+: "${REPO:?REPO env (owner/repo) required}"
+: "${GH_TOKEN:?GH_TOKEN env required}"
+
+PR_JSON="$(gh api "repos/${REPO}/pulls/${PR}")"
+BASE_SHA="$(printf '%s' "$PR_JSON" | jq -r '.base.sha')"
+HEAD_SHA="$(printf '%s' "$PR_JSON" | jq -r '.head.sha')"
+
+# Risk declared in the PR body (case-insensitive, optional backticks).
+BODY_RISK="$(printf '%s' "$PR_JSON" | jq -r '.body // ""' \
+  | grep -ioE 'risk level:[[:space:]]*`?(simple|complex|human-required)`?' \
+  | head -n 1 | grep -ioE '(simple|complex|human-required)' \
+  | head -n 1 | tr '[:upper:]' '[:lower:]' || true)"
+
+# A missing classifier means a broken checkout -> fail closed, never open.
+DIFF_RISK="human-required"
+if [ -f "$(dirname "$0")/classify-risk.sh" ]; then
+  DIFF_RISK="$(bash "$(dirname "$0")/classify-risk.sh" "$BASE_SHA" "$HEAD_SHA" || echo human-required)"
+fi
+
+rank() { case "$1" in human-required) echo 3;; complex) echo 2;; simple) echo 1;; *) echo 0;; esac; }
+if [ "$(rank "$DIFF_RISK")" -ge "$(rank "$BODY_RISK")" ]; then
+  echo "$DIFF_RISK"
+else
+  echo "$BODY_RISK"
+fi

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,119 @@
+name: Auto-merge (graduated autonomy)
+
+# Closes the loop for LOW-RISK PRs only. Merges a PR automatically when ALL hold:
+#   - the PR is open, not conflicting, and its head branch lives in THIS repo
+#     (fork PRs always wait for a human, whatever their risk)
+#   - effective risk == simple, RECOMPUTED from the default-branch classifier
+#     (a label is NOT trusted: Claude holds pull-requests:write and could self-label)
+#   - the LATEST Codex review on the current head commit is APPROVED
+#   - every REQUIRED check is green (gh pr checks --required)
+# A draft PR that passes every gate is marked ready and merged (claude.yml always
+# opens drafts and nothing else undrafts them). The merge is bound to the exact
+# head commit the gates validated (--match-head-commit): a push landing
+# mid-evaluation fails the merge instead of riding a stale approval.
+# complex / human-required PRs are never auto-merged; a human still merges those.
+#
+# OFF BY DEFAULT. Enable with repo variable AUTO_MERGE_ENABLED=true.
+# Prereqs: branch protection on the default branch with your CI (tsc/lint/test) as
+# REQUIRED checks, "Do not allow bypassing the above settings" enabled (the PAT
+# owner is usually an admin, and the merge API lets admins past red required
+# checks otherwise), and the merging identity (CLAUDE_PR_PAT) permitted to merge.
+on:
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to evaluate
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number || github.event.inputs.pr || github.event.check_suite.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  automerge:
+    if: ${{ vars.AUTO_MERGE_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch (trusted classifier source)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+
+      - name: Evaluate gates and maybe merge
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_PR_PAT }}
+          REPO: ${{ github.repository }}
+          CODEX_BOT: ${{ vars.CODEX_BOT_LOGIN }}
+          EVENT: ${{ github.event_name }}
+          REVIEW_PR: ${{ github.event.pull_request.number }}
+          DISPATCH_PR: ${{ github.event.inputs.pr }}
+          CHECK_SHA: ${{ github.event.check_suite.head_sha }}
+        run: |
+          set -euo pipefail
+          [ -z "${GH_TOKEN:-}" ] && { echo "CLAUDE_PR_PAT not set; skipping."; exit 0; }
+          CODEX_BOT="${CODEX_BOT:-chatgpt-codex-connector[bot]}"
+
+          # Resolve the PR number across the trigger types. ".[0].number // empty":
+          # a commit with no associated PR (every direct push's check_suite) must
+          # yield an empty string, not the literal "null".
+          PR="${REVIEW_PR:-${DISPATCH_PR:-}}"
+          if [ -z "$PR" ] && [ -n "${CHECK_SHA:-}" ]; then
+            PR="$(gh api "repos/$REPO/commits/$CHECK_SHA/pulls" --jq '.[0].number // empty' 2>/dev/null || true)"
+          fi
+          [ -z "$PR" ] && { echo "No PR to evaluate."; exit 0; }
+
+          # PR must be open, not conflicting, and from a branch in THIS repo:
+          # the design assumes the author is the Claude loop, so a fork PR
+          # (drive-by author) always waits for a human, whatever its risk.
+          read -r STATE DRAFT MERGEABLE HEAD_SHA HEAD_REPO < <(gh api "repos/$REPO/pulls/$PR" \
+            --jq '"\(.state) \(.draft) \(.mergeable_state) \(.head.sha) \(.head.repo.full_name)"')
+          [ "$STATE" = "open" ]  || { echo "PR #$PR not open ($STATE)."; exit 0; }
+          [ "$HEAD_REPO" = "$REPO" ] || { echo "PR #$PR head is from '$HEAD_REPO' (fork); a human merges this."; exit 0; }
+          [ "$MERGEABLE" != "dirty" ] || { echo "PR #$PR has conflicts."; exit 0; }
+
+          # Gate 1: effective risk == simple, recomputed via the default-branch
+          # classifier (never label-trusted).
+          RISK="$(bash .github/scripts/effective-risk.sh "$PR" || echo human-required)"
+          [ "$RISK" = "simple" ] || { echo "PR #$PR risk='$RISK' (not simple); a human merges this."; exit 0; }
+
+          # Gate 2: the LATEST Codex review on the CURRENT head is APPROVED.
+          # "Some approval exists on this head" is not enough: Codex can re-review
+          # the same commit (it's an LLM; re-runs differ) and request changes AFTER
+          # approving -- the newer verdict must win. Reviews are returned in
+          # submission order, so take the last one bound to this head.
+          LAST_STATE="$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate --jq \
+            '.[] | select(.user.login=="'"$CODEX_BOT"'" and .commit_id=="'"$HEAD_SHA"'") | .state' \
+            | tail -n 1 | tr '[:lower:]' '[:upper:]' || true)"
+          [ "$LAST_STATE" = "APPROVED" ] || { echo "Latest Codex review on head ${HEAD_SHA:0:12} is '${LAST_STATE:-<none>}' (need APPROVED); waiting."; exit 0; }
+
+          # Gate 3: every REQUIRED check green. --required scopes the gate to the
+          # branch-protection checks (the load-bearing CI): auxiliary event-driven
+          # runs (this workflow, the bridge) also attach check runs to the head,
+          # and one transient red auxiliary run must not block this head forever.
+          if ! gh pr checks "$PR" -R "$REPO" --required >/dev/null 2>&1; then
+            echo "Required checks not all green on PR #$PR; waiting for CI."; exit 0
+          fi
+
+          # All gates passed. claude.yml always opens PRs as drafts and nothing
+          # else undrafts them, so flipping ready here IS the arming step for the
+          # simple path -- without it auto-merge could never fire.
+          if [ "$DRAFT" = "true" ]; then
+            echo "PR #$PR passed all gates while draft; marking ready for review."
+            gh pr ready "$PR" -R "$REPO"
+          fi
+
+          # --match-head-commit: merge ONLY if the head is still the exact commit
+          # the gates validated -- a push landing mid-evaluation (a fix round, a
+          # human commit) fails the merge instead of riding a stale approval.
+          echo "PR #$PR: simple + Codex-approved on head ${HEAD_SHA:0:12} + required checks green -> merging."
+          gh pr merge "$PR" -R "$REPO" --squash --delete-branch --match-head-commit "$HEAD_SHA"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,13 @@ on:
   issues:
     types: [opened, assigned]
 
+# Serialize per conversation: concurrent runs for the same issue/PR would push
+# the same branch. One running + one queued; a third rapid-fire trigger replaces
+# the queued one (acceptable -- the queued run re-reads the conversation anyway).
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     # Require "@claude" AND a trusted actor; gates out drive-by non-collaborators.
@@ -117,3 +124,20 @@ jobs:
           echo "Opened draft PR: $URL"
           # Ask the official Codex GitHub app to review (works even while draft).
           gh pr comment "$URL" --body "@codex review"
+
+      # A failed run must leave a trace where the work item lives: the task
+      # dispatcher treats an open task issue with no PR as IN_FLIGHT forever, so
+      # a silent failure (API outage, action error) stalls the whole chain with
+      # the only signal buried in the Actions tab. The body deliberately avoids
+      # the "@claude" trigger phrase; github-actions[bot] is gated out anyway.
+      - name: Report failure on the triggering issue/PR
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ github.event.issue.number || github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          [ -n "${NUM:-}" ] || { echo "No issue/PR to report to."; exit 0; }
+          gh issue comment "$NUM" -R "$REPO" --body "Claude Code run failed: $RUN_URL -- no branch or PR may have been produced. Check the log, then re-trigger by commenting on this thread. <!-- claude-run-failed -->" || true

--- a/.github/workflows/codex-bridge.yml
+++ b/.github/workflows/codex-bridge.yml
@@ -15,13 +15,20 @@ name: Codex bridge
 #
 # Safeguards:
 # - Never merges anything.
+# - Fork PRs are never bridged: "@claude fix" must not task Claude with
+#   branch content this repo's collaborators never wrote.
+# - One run per PR at a time (concurrency group below): Codex fans one review
+#   out into many near-simultaneous events, and the marker-comment idempotency
+#   check is read-then-write -- parallel runs would each start a fix round.
 # - Risk = the stricter of the PR body's declared level and a fresh diff
 #   classification run from the DEFAULT-BRANCH classifier (a PR cannot weaken
 #   its own risk).
 # - Opt-in consent is bound to the exact head SHA (a >=7-char prefix), so it
 #   can't carry to a new head and can't be forged via a backdated commit date.
 #   A label is not used because Claude holds issues:write and could self-apply.
-# - One automated fix round per PR, guarded by the `claude-fix-requested` label.
+# - Automated fix rounds are capped per PR (MAX_FIX_ROUNDS, default 3) and derived
+#   from marker comments; each head commit is fixed at most once. Past the cap the
+#   bridge escalates to a human instead of looping.
 on:
   pull_request_review:
     types: [submitted]
@@ -34,6 +41,13 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+
+# Serialize per PR (one running + one queued; the queued run sees the marker
+# comment the first one posts and skips). cancel-in-progress stays false so an
+# in-flight decision is never killed mid-write.
+concurrency:
+  group: codex-bridge-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
 
 jobs:
   bridge:
@@ -55,6 +69,8 @@ jobs:
           # Codex review bot login. Override with repo variable CODEX_BOT_LOGIN if
           # your installation posts under a different account.
           CODEX_BOT: ${{ vars.CODEX_BOT_LOGIN }}
+          # Max automated fix rounds per PR before handing to a human (default 3).
+          MAX_FIX_ROUNDS: ${{ vars.MAX_FIX_ROUNDS }}
           # pull_request_review fields
           REVIEW_AUTHOR: ${{ github.event.review.user.login }}
           REVIEW_STATE: ${{ github.event.review.state }}
@@ -110,23 +126,20 @@ jobs:
             EVENT_COMMIT=""
           fi
 
-          # PR-level context needed by both trigger paths.
-          read -r BASE_SHA HEAD_SHA < <(gh api "repos/$REPO/pulls/$PR" --jq '"\(.base.sha) \(.head.sha)"')
+          # PR-level context needed by both trigger paths. Reject fork PRs
+          # outright: a fix request would run Claude (contents:write, API key)
+          # against branch content nobody in this repo wrote -- the loop only
+          # ever operates on same-repo claude/* branches.
+          read -r HEAD_SHA HEAD_REPO < <(gh api "repos/$REPO/pulls/$PR" --jq '"\(.head.sha) \(.head.repo.full_name)"')
+          if [ "$HEAD_REPO" != "$REPO" ]; then
+            echo "PR #$PR head is from '$HEAD_REPO' (fork); bridge only serves same-repo PRs."
+            exit 0
+          fi
 
           # Effective risk = stricter of (body-declared) and (fresh diff classification
           # via the DEFAULT-BRANCH classifier). A hand-edited body can't talk it down.
-          PR_BODY="$(gh pr view "$PR" -R "$REPO" --json body --jq '.body' || true)"
-          BODY_RISK="$(printf '%s' "$PR_BODY" \
-            | grep -ioE 'risk level:[[:space:]]*`?(simple|complex|human-required)`?' \
-            | head -n 1 | grep -ioE '(simple|complex|human-required)' \
-            | head -n 1 | tr '[:upper:]' '[:lower:]' || true)"
-          DIFF_RISK="human-required"
-          if [ -f .github/scripts/classify-risk.sh ]; then
-            DIFF_RISK="$(bash .github/scripts/classify-risk.sh "$BASE_SHA" "$HEAD_SHA" || echo human-required)"
-          fi
-          rank() { case "$1" in human-required) echo 3;; complex) echo 2;; simple) echo 1;; *) echo 0;; esac; }
-          if [ "$(rank "$DIFF_RISK")" -ge "$(rank "$BODY_RISK")" ]; then RISK="$DIFF_RISK"; else RISK="$BODY_RISK"; fi
-          echo "Risk: body='${BODY_RISK:-<none>}' diff='$DIFF_RISK' -> effective='$RISK'"
+          RISK="$(bash .github/scripts/effective-risk.sh "$PR" || echo human-required)"
+          echo "Effective risk: '$RISK'"
 
           # Opt-in BOUND TO THE EXACT HEAD COMMIT: a trusted human (OWNER/MEMBER/
           # COLLABORATOR, not a bot) commented "@claude allow-ai-fix <head-sha>" on the
@@ -164,6 +177,10 @@ jobs:
           # comments carry a commit_id we can bind to HEAD_SHA (issue-comment summaries do
           # not, so they don't count). This gates the human opt-in path: a human may only
           # authorize fixing findings that actually exist for this exact commit.
+          # DELIBERATE ASYMMETRY: inline comments count with NO keyword filter --
+          # Codex only leaves P0/P1 findings inline, so existence on the head is
+          # the signal. Don't "align" this with the keyword regex above; that one
+          # only classifies the TRIGGERING event.
           codex_flagged_head() {
             local n
             n="$( {
@@ -214,14 +231,34 @@ jobs:
             exit 0
           fi
 
-          # Loop guard: at most one automated fix round per PR.
-          if gh pr view "$PR" -R "$REPO" --json labels --jq '.labels[].name' | grep -qx 'claude-fix-requested'; then
-            echo "PR #$PR already has 'claude-fix-requested'; not requesting another fix."
+          # Loop guard: cap automated fix rounds per PR and never fire twice for the same
+          # head. Rounds are DERIVED from marker comments (no state stored outside GitHub),
+          # the same GitHub-derived-state model as the auto-task dispatcher.
+          MAX_ROUNDS="${MAX_FIX_ROUNDS:-3}"
+          ALL="$(gh api "repos/$REPO/issues/$PR/comments" --paginate --jq '.[].body' 2>/dev/null || true)"
+          # Count DISTINCT head=/round= markers, not raw occurrences: a human
+          # quote-reply of a fix comment copies the invisible marker verbatim
+          # and must not burn a round.
+          MARKERS="$(printf '%s' "$ALL" | grep -oE 'codex-bridge-fix head=[0-9a-f]+ round=[0-9]+' || true)"
+          ROUNDS="$(printf '%s\n' "$MARKERS" | sort -u | grep -c 'codex-bridge-fix' || true)"
+
+          # Idempotency: already asked for a fix on THIS exact head? (several Codex inline
+          # comments on one commit must not each start a round).
+          if printf '%s' "$ALL" | grep -q "head=$HEAD_SHA"; then
+            echo "Already requested a fix for head ${HEAD_SHA:0:12}; skipping duplicate."
             exit 0
           fi
 
-          gh label create claude-fix-requested -R "$REPO" --color 5319e7 \
-            --description "Codex requested changes; one automated Claude fix round triggered" --force >/dev/null 2>&1 || true
-          gh pr edit "$PR" -R "$REPO" --add-label claude-fix-requested
-          gh pr comment "$PR" -R "$REPO" --body "@claude fix Codex feedback. Address the Codex review comments in this PR, add or update tests if needed, and push the fix to this same PR branch. Do not open a new PR and do not merge."
-          echo "Requested a Claude fix on PR #$PR."
+          # Cap reached -> hand to a human (escalate once) and stop auto-fixing this PR.
+          if [ "${ROUNDS:-0}" -ge "$MAX_ROUNDS" ]; then
+            if ! printf '%s' "$ALL" | grep -q 'codex-bridge-escalated'; then
+              gh pr comment "$PR" -R "$REPO" --body "Automated fix loop hit its cap of $MAX_ROUNDS round(s) and Codex still has findings. Handing this PR to a human; no further automated fixes will be requested. <!-- codex-bridge-escalated -->"
+            fi
+            echo "Fix-round cap ($MAX_ROUNDS) reached on PR #$PR; escalated to a human."
+            exit 0
+          fi
+
+          # Request the next fix round. The @claude line triggers claude.yml; the invisible
+          # HTML marker records the head + round for the counter above.
+          gh pr comment "$PR" -R "$REPO" --body "@claude fix Codex feedback. Address the Codex review comments in this PR, add or update tests if needed, and push the fix to this same PR branch. Do not open a new PR and do not merge. <!-- codex-bridge-fix head=$HEAD_SHA round=$((ROUNDS+1)) -->"
+          echo "Requested Claude fix round $((ROUNDS+1))/$MAX_ROUNDS on PR #$PR (head ${HEAD_SHA:0:12})."

--- a/.github/workflows/risk-label.yml
+++ b/.github/workflows/risk-label.yml
@@ -28,10 +28,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          # Passed via env (never inlined into the script) to avoid injection.
-          BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
 
@@ -40,29 +36,16 @@ jobs:
           gh label create complex        -R "$REPO" --color fbca04 --description "Non-trivial logic; deeper review needed" --force >/dev/null 2>&1 || true
           gh label create human-required -R "$REPO" --color b60205 --description "Sensitive area; requires human review, no auto-approve" --force >/dev/null 2>&1 || true
 
-          # Risk declared in the PR body (case-insensitive, optional backticks).
-          BODY_RISK="$(printf '%s' "$BODY" \
-            | grep -ioE 'risk level:[[:space:]]*`?(simple|complex|human-required)`?' \
-            | head -n 1 \
-            | grep -ioE '(simple|complex|human-required)' \
-            | head -n 1 \
-            | tr '[:upper:]' '[:lower:]' || true)"
-
-          # Risk classified from the diff (fall back to body-only if script absent).
-          DIFF_RISK=""
-          if [ -f .github/scripts/classify-risk.sh ]; then
-            DIFF_RISK="$(bash .github/scripts/classify-risk.sh "$BASE_SHA" "$HEAD_SHA" || true)"
-          fi
-
-          # Effective risk = the stricter of the two.
-          rank() { case "$1" in human-required) echo 3;; complex) echo 2;; simple) echo 1;; *) echo 0;; esac; }
-          if [ "$(rank "$DIFF_RISK")" -ge "$(rank "$BODY_RISK")" ]; then RISK="$DIFF_RISK"; else RISK="$BODY_RISK"; fi
+          # Effective risk (stricter of body-declared and fresh diff classification),
+          # from the SAME script the bridge and auto-merge enforce -- one source,
+          # so the visible label can't drift from the actual gates.
+          RISK="$(bash .github/scripts/effective-risk.sh "$PR" || true)"
 
           if [ -z "${RISK:-}" ]; then
-            echo "No risk determinable (no body line, no diff); leaving labels unchanged."
+            echo "No risk determinable; leaving labels unchanged."
             exit 0
           fi
-          echo "Effective risk: body='${BODY_RISK:-<none>}' diff='${DIFF_RISK:-<none>}' -> '$RISK'"
+          echo "Effective risk: '$RISK'"
 
           # Remove any stale risk labels, then apply the effective one.
           for l in simple complex human-required; do

--- a/.github/workflows/task-dispatcher.yml
+++ b/.github/workflows/task-dispatcher.yml
@@ -1,0 +1,49 @@
+name: Auto task dispatcher
+
+# Stateless dispatcher: reads immutable manifests from the default branch
+# (.github/auto-tasks/<slug>/tasks.json) and derives each task's state from
+# issues/PRs every run -- it never writes the manifest or pushes to the
+# protected default branch. Opens the next eligible task as an "@claude" issue
+# via CLAUDE_PR_PAT (so claude.yml fires), one task per merged PR. Never merges.
+# See .github/scripts/dispatch-tasks.sh and .github/auto-tasks/README.md.
+#
+# Start a chain: merge a PR adding .github/auto-tasks/<slug>/tasks.json with
+#   "paused": false (see the split-task skill), or run this workflow manually.
+# Stop: set "paused": true in the manifest, or repo variable AUTO_TASKS_ENABLED=false.
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: auto-task-dispatcher
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch (read-only)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+
+      - name: Dispatch next task
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_PR_PAT }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          AUTO_TASKS_ENABLED: ${{ vars.AUTO_TASKS_ENABLED }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "CLAUDE_PR_PAT is not set; cannot open task issues that trigger claude.yml."
+            exit 0
+          fi
+          bash .github/scripts/dispatch-tasks.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,9 @@ Being invoked via `@claude` is explicit authorization to commit to a working bra
 ### Working style
 - Create small, focused pull requests. One concern per PR.
 - Never push directly to `main`. Always work on a branch; the automation opens the PR (see "Opening the pull request").
-- Never auto-merge. Codex review and the human owner decide.
+- Never merge or mark a PR ready for review yourself. Codex review and the human
+  owner decide; a separate auto-merge workflow (OFF by default, repo variable
+  `AUTO_MERGE_ENABLED`) may merge `simple` PRs when the owner enables it.
 - Write a clear PR description with: a short summary of the change, the reason, the files touched, and the checks you ran with their results.
 
 ### Risk level (classified automatically)

--- a/test/classify-risk-patterns.test.sh
+++ b/test/classify-risk-patterns.test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Offline check of classify-risk.sh's denylist: universal BASE + per-repo EXTRA
+# (from auto/sensitive-paths.txt) + size buckets. Runs the REAL script against a
+# fake `gh` that returns fixture compare JSON, so there is no logic to drift.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/.github/scripts/classify-risk.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# fake gh: `gh api <compare-path>` -> emit the fixture named by $GH_FIXTURE.
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+[ "$1" = "api" ] && cat "$GH_FIXTURE" || exit 0
+EOF
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+
+# Script copies with the right relative layout (script reads ../auto/...):
+#  WITHCFG has a sensitive-paths.txt with a repo-specific pattern; NOCFG has
+#  none; BADCFG has a malformed regex line (must fail closed, not fall through).
+for d in WITHCFG NOCFG BADCFG; do mkdir -p "$TMP/$d/scripts" "$TMP/$d/auto"; cp "$SCRIPT" "$TMP/$d/scripts/"; done
+printf '(^|/)src/app/api/   # server API routes\n# a comment line\n' >"$TMP/WITHCFG/auto/sensitive-paths.txt"
+printf '(^|/src/api   # malformed: unbalanced paren\n' >"$TMP/BADCFG/auto/sensitive-paths.txt"
+
+# build a compare-JSON fixture from "path:add:del" specs
+fixture() { local out='{"files":['; local first=1 p; for spec in "$@"; do
+    IFS=: read -r p a del <<<"$spec"
+    [ $first -eq 1 ] || out+=','; first=0
+    out+="{\"filename\":\"$p\",\"additions\":${a:-1},\"deletions\":${del:-0}}"
+  done; out+=']}'; printf '%s' "$out"; }
+
+fails=0
+check() { # <label> <scriptdir> <expected> <spec...>
+  local label="$1" sdir="$2" want="$3"; shift 3
+  printf '%s' "$(fixture "$@")" >"$TMP/fix.json"
+  local got; got="$(GH_FIXTURE="$TMP/fix.json" REPO=o/r GH_TOKEN=t bash "$TMP/$sdir/scripts/classify-risk.sh" base head)"
+  if [ "$got" = "$want" ]; then echo "PASS  $label ($got)"; else echo "FAIL  $label: want=$want got=$got"; fails=$((fails+1)); fi
+}
+
+# EXTRA (repo-specific) match
+check "extra: src/app/api"        WITHCFG human-required "src/app/api/route.ts:2:0"
+# BASE matches, cross-ecosystem
+check "base: package.json"        WITHCFG human-required "package.json:2:0"
+check "base: requirements.txt"    WITHCFG human-required "app/models.py:2:0" "requirements.txt:1:0"
+check "base: .env file"           WITHCFG human-required "config/.env.local:1:0"
+check "base: keyword payment"     WITHCFG human-required "src/lib/payment.ts:1:0"
+# non-sensitive size buckets
+check "simple: one small doc"     WITHCFG simple         "README.md:2:0"
+check "complex: >5 files"         WITHCFG complex        "docs/a.md:1:0" "docs/b.md:1:0" "docs/c.md:1:0" "docs/d.md:1:0" "docs/e.md:1:0" "docs/f.md:1:0"
+check "complex: >150 lines"       WITHCFG complex        "src/lib/util.ts:200:0"
+# design proof: without the repo config, the api boundary is NOT protected
+check "no-config: api -> simple"  NOCFG   simple         "src/app/api/route.ts:2:0"
+# fail closed: a malformed EXTRA regex (grep error) must not silently disable
+# the sensitive check -- an innocuous file still classifies human-required
+check "bad-config: fail closed"   BADCFG  human-required "README.md:2:0"
+
+echo; [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/test/effective-risk.test.sh
+++ b/test/effective-risk.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Offline check of effective-risk.sh: body-line extraction and the
+# stricter-of(body, diff) rule that codex-bridge, risk-label and auto-merge all
+# gate on. Runs the REAL scripts against a path-aware fake `gh`.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# fake gh: `gh api .../pulls/<n>` -> $PR_FIXTURE, `gh api .../compare/...` -> $CMP_FIXTURE
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+case "${2:-}" in
+  */compare/*) cat "$CMP_FIXTURE" ;;
+  */pulls/*)   cat "$PR_FIXTURE" ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+
+mkdir -p "$TMP/scripts" "$TMP/auto"
+cp "$ROOT/.github/scripts/effective-risk.sh" "$ROOT/.github/scripts/classify-risk.sh" "$TMP/scripts/"
+
+# compare fixtures: one small doc file -> simple; one big file -> complex
+printf '{"files":[{"filename":"README.md","additions":2,"deletions":0}]}' >"$TMP/cmp-simple.json"
+printf '{"files":[{"filename":"src/lib/util.ts","additions":200,"deletions":0}]}' >"$TMP/cmp-complex.json"
+
+pr_fixture() { # <body> -> writes $TMP/pr.json
+  jq -n --arg body "$1" '{base:{sha:"b"},head:{sha:"h"},body:$body}' >"$TMP/pr.json"
+}
+
+fails=0
+check() { # <label> <cmp-fixture> <expected>   (pr.json prepared by caller)
+  local label="$1" cmp="$2" want="$3" got
+  got="$(PR_FIXTURE="$TMP/pr.json" CMP_FIXTURE="$TMP/$cmp" REPO=o/r GH_TOKEN=t \
+    bash "$TMP/scripts/effective-risk.sh" 7)"
+  if [ "$got" = "$want" ]; then echo "PASS  $label ($got)"; else echo "FAIL  $label: want=$want got=$got"; fails=$((fails+1)); fi
+}
+
+pr_fixture 'Automated draft PR.'
+check "no body line -> diff wins"           cmp-simple.json  simple
+
+pr_fixture $'Summary.\n\nRisk level: human-required\n'
+check "stricter body beats simple diff"     cmp-simple.json  human-required
+
+pr_fixture $'Summary.\n\nrisk level: `simple`\n'
+check "weaker body cannot beat complex diff" cmp-complex.json complex
+
+echo; [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
## Summary

Syncs this repo's automation loop with the hardened agentic-ci template
(github.com/ysna99/agentic-ci @ 3145ac8), which originated from this repo and
just went through an adversarial review pass (14 findings fixed). Also lands
the two pieces that were built and validated earlier but never pushed: the
stateless task dispatcher and graduated-autonomy auto-merge.

## What changes for the existing loop

- codex-bridge: the one-round `claude-fix-requested` label guard becomes a
  capped, stateless round counter (repo var `MAX_FIX_ROUNDS`, default 3)
  derived from marker comments; findings and human opt-in are bound to the
  exact head SHA; per-PR concurrency closes a race where Codex's N inline
  comments each started a parallel fix round; fork PRs are excluded.
- claude.yml: per-conversation concurrency; a failed run now comments the run
  URL on the triggering issue/PR instead of failing silently.
- classify-risk.sh: the repo-specific denylist moves to
  `.github/auto/sensitive-paths.txt` (env constants, middleware, app/api,
  apis, pocha, stripe, cloudinary, customer). Boundaries are IDENTICAL --
  verified by a 12-case parity check against the old hardcoded pattern. The
  classifier now fails closed if a config line is a malformed regex.
- New `effective-risk.sh`: the stricter-of(body, diff) computation the bridge,
  risk-label, and auto-merge previously each copy-pasted.

## New, inert until armed

- task-dispatcher.yml + dispatch-tasks.sh: stateless multi-task chain; does
  nothing until a `.github/auto-tasks/<slug>/tasks.json` with `paused: false`
  is merged (author one with the /split-task skill).
- auto-merge.yml: OFF by default. When `AUTO_MERGE_ENABLED=true`, merges only
  simple + latest Codex approval on the current head + required checks green,
  and binds the merge to the validated head (`--match-head-commit`). It also
  marks a fully-passing simple draft PR ready (nothing else ever undrafts).

## Checks run

- `bash -n` on all scripts; YAML parse on all six workflows
- `test/classify-risk-patterns.test.sh` 10/10 (includes new fail-closed case)
- `test/effective-risk.test.sh` 3/3
- 12-case denylist parity check (old hardcoded pattern vs new config): PASS

## Before enabling auto-merge (not needed to merge this PR)

1. Branch protection: CI as REQUIRED checks and "Do not allow bypassing the
   above settings" enabled (the merging PAT belongs to an admin).
2. Confirm the Codex app actually leaves APPROVED reviews; set
   `CODEX_BOT_LOGIN` if its login differs from `chatgpt-codex-connector[bot]`.
3. Set repo var `AUTO_MERGE_ENABLED=true`.

Housekeeping: the stale `feat/auto-task-dispatcher` branch on origin is dead
(its commit was merged then reverted) and can be deleted.

Generated with [Claude Code](https://claude.com/claude-code)